### PR TITLE
Allow easy inspection of garbled code

### DIFF
--- a/testdata/scripts/debugdir.txt
+++ b/testdata/scripts/debugdir.txt
@@ -1,0 +1,21 @@
+garble -debugdir ./test1 build
+exists 'test1/test/imported/z0.go' 'test1/main/z0.go'
+! grep ImportedFunc $WORK/test1/test/imported/z0.go
+! grep ImportedFunc $WORK/test1/main/z0.go 
+
+
+-- go.mod --
+module test
+-- main.go --
+package main
+
+import "test/imported"
+
+func main() {
+	imported.ImportedFunc()
+}
+
+-- imported/imported.go --
+package imported
+
+func ImportedFunc() {}


### PR DESCRIPTION
To test that it works:
```
mkdir inspectCodeTest
cd inspectCodeTest
git clone https://github.com/lu4p/garble.git
cd garble
git checkout inspectCode
go install
cd ..
git clone https://github.com/lu4p/cat.git
cd cat/cmd/cat
garble -debugdir ./test -literals build
find ./test
```