### PR TITLE
Fix broken -seed=random

### DIFF
--- a/crypto.go
+++ b/crypto.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"fmt"
 	mathrand "math/rand"
+	"strings"
 )
 
 // If math/rand.Seed() is not called, the generator behaves as if seeded by rand.Seed(1),
@@ -25,7 +26,7 @@ func genNonce() []byte {
 func genRandBytes(size int) []byte {
 	buffer := make([]byte, size)
 
-	if envGarbleSeed == "random" {
+	if strings.HasPrefix(envGarbleSeed, "random;") {
 		_, err := rand.Read(buffer)
 		if err != nil {
 			panic(fmt.Sprintf("couldn't generate random key:  %v", err))

--- a/strings.go
+++ b/strings.go
@@ -240,17 +240,3 @@ func keyStmt(key []byte) *ast.GenDecl {
 		}},
 	}
 }
-
-var cryptoAesImportSpec = &ast.GenDecl{
-	Tok: token.IMPORT,
-	Specs: []ast.Spec{
-		&ast.ImportSpec{Path: &ast.BasicLit{
-			Kind:  token.STRING,
-			Value: `"crypto/aes"`,
-		}},
-		&ast.ImportSpec{Path: &ast.BasicLit{
-			Kind:  token.STRING,
-			Value: `"crypto/cipher"`,
-		}},
-	},
-}

--- a/testdata/scripts/seed.txt
+++ b/testdata/scripts/seed.txt
@@ -1,43 +1,53 @@
 # Check the binary with a given base64 encoded seed
-garble -literals -seed=OQg9kACEECQ= build main.go
+garble -literals -seed=OQg9kACEECQ= build
 exec ./main$exe
 cmp stderr main.stdout   
-! binsubstr  main$exe 'teststring' 'teststringVar'
+! binsubstr  main$exe 'teststring' 'teststringVar' 'imported var value' 'ImportedVar'
 
 [short] stop # checking that the build is reproducible and random is slow
 
 # Also check that the binary is reproducible.
 cp main$exe main_old$exe
 rm main$exe
-garble -literals -seed=OQg9kACEECQ= build main.go
+garble -literals -seed=OQg9kACEECQ= build
 bincmp main$exe main_old$exe
 
 # Also check that a different seed leads to a different binary
 cp main$exe main_old$exe
 rm main$exe
-garble -literals -seed=NruiDmVz6/s= build main.go
+garble -literals -seed=NruiDmVz6/s= build
 ! bincmp main$exe main_old$exe
 
 # Check the random binary
-garble -literals -seed=random build main.go
+garble -literals -seed=random build
 exec ./main$exe
 cmp stderr main.stdout
-! binsubstr  main$exe 'teststring' 'teststringVar'
+! binsubstr  main$exe 'teststring' 'teststringVar' 'imported var value' 'ImportedVar'
 
 # Also check that the random binary is not reproducible.
 cp main$exe main_old$exe
 rm main$exe
-garble -literals -seed=random build main.go
+garble -literals -seed=random build
 ! bincmp main$exe main_old$exe
 
+-- go.mod --
+module test/main
 -- main.go --
 package main
+
+import "test/main/imported"
 
 var teststringVar = "teststring"
 
 func main() {
 	println(teststringVar)
+	println(imported.ImportedVar)
 }
+-- imported/imported.go --
+package imported
+
+var ImportedVar = "imported var value"
 
 -- main.stdout --
 teststring
+imported var value


### PR DESCRIPTION
@mvdan I realized that the current `-seed=random` flag is broken, because I generate a new seed for each garbled package. Which leads to the garbled identifiers of imported packages being broken. 

Other builds with `-seed=base64` or without `-seed` are  unaffected.

Also added an import to the seed test so it doesn't get broken again.

Furthermore I removed the now unused `cryptoAesImportSpec`