### PR TITLE
Use printing verb %q to encode byte slices.

### DIFF
--- a/strings.go
+++ b/strings.go
@@ -6,7 +6,6 @@ import (
 	"go/token"
 	"go/types"
 	"strconv"
-	"strings"
 
 	"golang.org/x/tools/go/ast/astutil"
 )
@@ -285,22 +284,14 @@ func ciphertextStmt(ciphertext []byte) *ast.CallExpr {
 
 // dataToByteSlice turns a byte slice like []byte{1, 2, 3} into an AST
 // expression
-func dataToByteSlice(data []byte) *ast.CompositeLit {
-	var builder strings.Builder
-
-	for _, b := range data {
-		builder.WriteString(strconv.FormatInt(int64(b), 10) + ",")
-	}
-
-	return &ast.CompositeLit{
-		Type: &ast.ArrayType{
-			Elt: &ast.Ident{
-				Name: "byte",
-			},
+func dataToByteSlice(data []byte) *ast.CallExpr {
+	return &ast.CallExpr{
+		Fun: &ast.ArrayType{
+			Elt: &ast.Ident{Name: "byte"},
 		},
-		Elts: []ast.Expr{&ast.BasicLit{
+		Args: []ast.Expr{&ast.BasicLit{
 			Kind:  token.STRING,
-			Value: builder.String(),
+			Value: fmt.Sprintf("%q", data),
 		}},
 	}
 }


### PR DESCRIPTION
I now implemented and tested hex encoded strings, binary literals and `fmt.Sprintf("%q", data)` in the case of garble all produce the exact same binary size.

I decided to use `fmt.Sprintf("%q", data)` because it is the simplest, leads to the smallest garbled code file size size of the three, and is faster at compile time than binary literals.

It looks something like this:
```go
var (
	ziOlrRzMK	string	= garbleDecrypt([]byte("\x1f\xadb'\xf8\x15\x81\x9e\x05 \xba\v\x15\U000b16dc\x10]e)Ų\\\xebq\x18$\x8b\xb2ay\x15"))
	ztN0xdMLL		= garbleDecrypt([]byte("\xaf\xbd\x01\\&\x14\xab\xeb\x94\x10Q\xf2H#\xde\x17\a\x8f\x89MmZs\u0088\xcfw\xba?\x9e\xe1\x81\x1eպD\xe1@\xf2\x8d\xe3Ije\xca\bB\xbey\x8b"))
)

```

## From the fmt Docs:

String and slice of bytes (treated equivalently with these verbs):
```
%s	the uninterpreted bytes of the string or slice
%q	a double-quoted string safely escaped with Go syntax
%x	base 16, lower-case, two characters per byte
%X	base 16, upper-case, two characters per byte
```

Fixes #40.
