### PR TITLE
Skip literals used in constant expressions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /garble
+/test

--- a/main.go
+++ b/main.go
@@ -666,7 +666,7 @@ func buildBlacklist(files []*ast.File, info *types.Info, pkg *types.Package) map
 	}
 	visit := func(node ast.Node) bool {
 		if envGarbleLiterals {
-			strConstBlacklist(node, info, blacklist)
+			constBlacklist(node, info, blacklist)
 		}
 
 		if node == nil {

--- a/strings.go
+++ b/strings.go
@@ -43,7 +43,7 @@ func containsTypeDefStr(expr ast.Expr, info *types.Info) bool {
 	return false
 }
 
-func obfuscateLiterals(files []*ast.File, info *types.Info) []*ast.File {
+func obfuscateLiterals(files []*ast.File, info *types.Info, blacklist map[types.Object]struct{}) []*ast.File {
 	pre := func(cursor *astutil.Cursor) bool {
 		switch x := cursor.Node().(type) {
 		case *ast.ValueSpec:
@@ -89,6 +89,15 @@ func obfuscateLiterals(files []*ast.File, info *types.Info) []*ast.File {
 				spec, ok := spec.(*ast.ValueSpec)
 				if !ok {
 					return false
+				}
+
+				for _, name := range spec.Names {
+					obj := info.ObjectOf(name)
+
+					// The object itself is blacklisted, e.g. a value that needs to be constant
+					if _, ok := blacklist[obj]; ok {
+						return false
+					}
 				}
 
 				for _, val := range spec.Values {
@@ -304,5 +313,53 @@ func keyStmt(key []byte) *ast.GenDecl {
 			Names:  []*ast.Ident{{Name: "garbleKey"}},
 			Values: []ast.Expr{keyLit},
 		}},
+	}
+}
+
+func strConstBlacklist(node ast.Node, info *types.Info, blacklist map[types.Object]struct{}) {
+	strType := types.Typ[types.String]
+	untypedStr := types.Typ[types.UntypedString]
+
+	constCheck := func(node ast.Node) bool {
+		ident, ok := node.(*ast.Ident)
+		if !ok {
+			return true
+		}
+
+		obj := info.ObjectOf(ident)
+		if obj.Type() == strType || obj.Type() == untypedStr {
+			blacklist[obj] = struct{}{}
+		}
+		return true
+	}
+
+	switch x := node.(type) {
+	case *ast.CompositeLit:
+		if _, ok := x.Type.(*ast.ArrayType); !ok {
+			break
+		}
+		for _, elt := range x.Elts {
+			if kv, ok := elt.(*ast.KeyValueExpr); ok {
+				ast.Inspect(kv.Key, constCheck)
+			}
+		}
+	case *ast.ArrayType:
+		if x.Len != nil {
+			ast.Inspect(x.Len, constCheck)
+		}
+	case *ast.GenDecl:
+		if x.Tok != token.CONST {
+			break
+		}
+		for _, spec := range x.Specs {
+			spec, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+
+			for _, val := range spec.Values {
+				ast.Inspect(val, constCheck)
+			}
+		}
 	}
 }

--- a/testdata/scripts/strings.txt
+++ b/testdata/scripts/strings.txt
@@ -134,15 +134,18 @@ func constantTest() {
 
 	const d = "foo" // skip
 	var arr = [5]string{len(d): "foo"}
-
 	for _, elm := range arr {
-		println(elm)
+		if elm != "" {
+			println(elm)
+		}
 	}
 
 	const e = "foo" // skip
 	var slice = []string{len(e): "foo"}
 	for _, elm := range slice {
-		println(elm)
+		if elm != "" {
+			println(elm)
+		}
 	}
 
 	const f = "foo" // skip
@@ -171,12 +174,5 @@ stringTypeField String stringTypeField strType
 stringType lambda func return
 stringType func param
 stringType return
-
-
-
 foo
-
-
-
-
 foo

--- a/testdata/scripts/strings.txt
+++ b/testdata/scripts/strings.txt
@@ -78,6 +78,7 @@ func main() {
 	println(skip1, skip2)
 	println(i, foo, bar)
 	typedTest()
+	constantTest()
 }
 
 type stringType string
@@ -98,7 +99,7 @@ func typedTest() {
 	println(skipTypedConst, skipTypedVar, skipTypedVarAssign)
 
 	y := stringTypeStruct{
-		str:     "stringTypeField String",     // obfuscate
+		str:     "stringTypeField String",  // obfuscate
 		strType: "stringTypeField strType", // skip
 	}
 	println(y.str, y.strType)
@@ -118,6 +119,34 @@ func typedTest() {
 	testMap3["testMap3 key"] = "testMap3 new value"                         // skip
 
 	println(stringTypeFunc("stringType func param")) // skip
+}
+
+// constantTest tests that string constants which need to be constant are skipped
+func constantTest() {
+	const a = "foo" // skip
+	const length = len(a)
+
+	const b = "bar" // skip
+	type T [len(b)]byte
+
+	const c = "foo" // skip
+	var _ [len(c)]byte
+
+	const d = "foo" // skip
+	var arr = [5]string{len(d): "foo"}
+
+	for _, elm := range arr {
+		println(elm)
+	}
+
+	const e = "foo" // skip
+	var slice = []string{len(e): "foo"}
+	for _, elm := range slice {
+		println(elm)
+	}
+
+	const f = "foo" // skip
+	const i = length + len(f)
 }
 
 func stringTypeFunc(s stringType) stringType {
@@ -142,3 +171,12 @@ stringTypeField String stringTypeField strType
 stringType lambda func return
 stringType func param
 stringType return
+
+
+
+foo
+
+
+
+
+foo


### PR DESCRIPTION
```go
const x = "foo" // skip
const length = len(x)
```

```go
const y = "foo" // skip
type T [len(y)]byte
```

Fixes #39.