### PR TITLE
Implemented stronger string obfuscation

### DIFF
--- a/crypto.go
+++ b/crypto.go
@@ -4,6 +4,7 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
+	"encoding/binary"
 	"fmt"
 	mathrand "math/rand"
 	"strings"
@@ -36,6 +37,15 @@ func genRandBytes(size int) []byte {
 	}
 
 	return buffer
+}
+
+func genRandUInt32() uint32 {
+	bytes := genRandBytes(4)
+	return binary.LittleEndian.Uint32(bytes)
+}
+
+func genRandUInt32Max(max uint32) uint32 {
+	return genRandUInt32() % max
 }
 
 // encAES encrypt data with key in AES GCM mode.


### PR DESCRIPTION
Original:
```go
println("another literal")
```

Obfuscated:
```go
println(garbleDecrypt([]byte("\xcac\rS0l\xe3\x8a\x16$p\x00\xba\x14\x82g\xaa\xbf\x81\xe2F\x8b\xca-\x06hP\xb7~&\xa4\xa2I\xef{\x11\x1c\xb6r\xb0{0V")))
```

New:
```go
println(func(zoZTaXL_4, zBitFPYIF uint32) string {
		zFzBjwnaj := []byte("\xcac\rS0l\xe3\x8a\x16$p\x00\xba\x14\x82g\xaa\xbf\x81\xe2F\x8b\xca-\x06hP\xb7~&\xa4\xa2I\xef{\x11\x1c\xb6r\xb0{0V")
		{
			zFzBjwnaj[int(zBitFPYIF>>26%43)] ^= byte(zBitFPYIF >> 13)
			zFzBjwnaj[int(zoZTaXL_4>>31%43)] ^= byte(zoZTaXL_4 >> 0)
			zFzBjwnaj[int(zBitFPYIF>>16%43)] ^= byte(zBitFPYIF >> 8)
			zFzBjwnaj[int(zoZTaXL_4>>28%43)] ^= byte(zoZTaXL_4 >> 2)
			zFzBjwnaj[int(zBitFPYIF>>22%43)] ^= byte(zBitFPYIF >> 0)
			zFzBjwnaj[int(zoZTaXL_4>>20%43)] ^= byte(zoZTaXL_4 >> 10)
		}
		return garbleDecrypt(zFzBjwnaj)
	}(2864075088, 885107377))
```
