### PR TITLE
fix implementedOutsideGo, fixes #56

### DIFF
--- a/main.go
+++ b/main.go
@@ -831,7 +831,7 @@ func transformGo(file *ast.File, info *types.Info, blacklist map[types.Object]st
 // do not differentiate these "external funcs" in any way.
 func implementedOutsideGo(obj *types.Func) bool {
 	return obj.Type().(*types.Signature).Recv() == nil &&
-		(obj.Scope() != nil && obj.Scope().Pos() == token.NoPos)
+		(obj.Scope() != nil && obj.Scope().End() == token.NoPos)
 }
 
 // named tries to obtain the *types.Named behind a type, if there is one.

--- a/testdata/scripts/strings.txt
+++ b/testdata/scripts/strings.txt
@@ -2,7 +2,7 @@
 garble -literals build
 exec ./main$exe
 cmp stderr main.stderr
-! binsubstr main$exe 'Lorem' 'ipsum' 'dolor' 'first assign' 'second assign' 'First Line' 'Second Line' 'map value' 'to obfuscate' 'also obfuscate' 'stringTypeField String' 'stringTypeStruct'
+! binsubstr main$exe 'garbleDecrypt' 'Lorem' 'ipsum' 'dolor' 'first assign' 'second assign' 'First Line' 'Second Line' 'map value' 'to obfuscate' 'also obfuscate' 'stringTypeField String' 'stringTypeStruct'
 
 binsubstr main$exe 'Skip this block,' 'also skip this' 'skip typed const' 'skip typed var' 'skip typed var assign' 'stringTypeField strType' 'stringType lambda func return' 'testMap1 key' 'testMap2 key' 'testMap3 key' 'testMap1 value' 'testMap2 value' 'testMap3 value' 'testMap1 new value' 'testMap2 new value' 'testMap3 new value' 'stringType func param' 'stringType return'
 [short] stop # checking that the build is reproducible is slow


### PR DESCRIPTION
Injected functions were mistaken for functions implemented outside go.

Asm functions:
obj.Scope().Pos() == 0
obj.Scope().End() == 0

Injected functions:
obj.Scope().Pos() == 0
obj.Scope().End() == 1

We now check for the End instead of the Pos.