### PR TITLE
Add float, int, and boolean literal obfuscation.

### DIFF
--- a/internal/literals/asthelpers.go
+++ b/internal/literals/asthelpers.go
@@ -1,0 +1,71 @@
+package literals
+
+import (
+	"go/ast"
+	"go/token"
+	"strconv"
+)
+
+func ident(name string) *ast.Ident {
+	return &ast.Ident{Name: name}
+}
+func intLiteral(value string) *ast.BasicLit {
+	return &ast.BasicLit{
+		Kind:  token.INT,
+		Value: value,
+	}
+}
+
+// name[index]
+func indexExpr(name string, index ast.Expr) *ast.IndexExpr {
+	return &ast.IndexExpr{
+		X:     ident(name),
+		Index: index,
+	}
+}
+
+// fun(arg)
+func callExpr(fun ast.Expr, arg ast.Expr) *ast.CallExpr {
+	var args []ast.Expr
+	if arg != nil {
+		args = []ast.Expr{arg}
+	}
+
+	return &ast.CallExpr{
+		Fun:  fun,
+		Args: args,
+	}
+}
+
+// func() resultType {block}()
+func lambdaCall(resultType ast.Expr, block *ast.BlockStmt) *ast.CallExpr {
+	funcLit := &ast.FuncLit{
+		Type: &ast.FuncType{
+			Params: &ast.FieldList{},
+			Results: &ast.FieldList{
+				List: []*ast.Field{
+					{Type: resultType},
+				},
+			},
+		},
+		Body: block,
+	}
+	return callExpr(funcLit, nil)
+}
+
+// return result
+func returnStmt(results ...ast.Expr) *ast.ReturnStmt {
+	return &ast.ReturnStmt{
+		Results: results,
+	}
+}
+
+// _ = data[pos]
+func boundsCheckData(pos int) *ast.AssignStmt {
+	posStr := strconv.Itoa(pos)
+	return &ast.AssignStmt{
+		Lhs: []ast.Expr{ident("_")},
+		Tok: token.ASSIGN,
+		Rhs: []ast.Expr{indexExpr("data", intLiteral(posStr))},
+	}
+}

--- a/internal/literals/numbers.go
+++ b/internal/literals/numbers.go
@@ -1,0 +1,229 @@
+package literals
+
+import (
+	"encoding/binary"
+	"errors"
+	"go/ast"
+	"go/token"
+	"go/types"
+	"math"
+	"reflect"
+	"strconv"
+
+	"golang.org/x/tools/go/ast/astutil"
+)
+
+var intTypes = map[types.Type]reflect.Type{
+	types.Typ[types.UntypedInt]: reflect.TypeOf(int(0)),
+	types.Typ[types.Int]:        reflect.TypeOf(int(0)),
+	types.Typ[types.Int8]:       reflect.TypeOf(int8(0)),
+	types.Typ[types.Int16]:      reflect.TypeOf(int16(0)),
+	types.Typ[types.Int32]:      reflect.TypeOf(int32(0)),
+	types.Typ[types.Int64]:      reflect.TypeOf(int64(0)),
+	types.Typ[types.Uint]:       reflect.TypeOf(uint(0)),
+	types.Typ[types.Uint8]:      reflect.TypeOf(uint8(0)),
+	types.Typ[types.Uint16]:     reflect.TypeOf(uint16(0)),
+	types.Typ[types.Uint32]:     reflect.TypeOf(uint32(0)),
+	types.Typ[types.Uint64]:     reflect.TypeOf(uint64(0)),
+	types.Typ[types.Uintptr]:    reflect.TypeOf(uintptr(0)),
+}
+
+func obfuscateNumberLiteral(cursor *astutil.Cursor, info *types.Info) error {
+	var (
+		call     *ast.CallExpr
+		basic    *ast.BasicLit
+		ok       bool
+		typeInfo types.Type
+	)
+
+	sign := ""
+	node := cursor.Node()
+
+	switch x := node.(type) {
+	case *ast.UnaryExpr:
+		basic, ok = x.X.(*ast.BasicLit)
+		if !ok {
+			return errors.New("UnaryExpr doesn't contain basic literal")
+		}
+		typeInfo = info.TypeOf(x)
+
+		if x.Op != token.SUB {
+			return errors.New("UnaryExpr has a non SUB token")
+		}
+		sign = "-"
+
+		switch y := cursor.Parent().(type) {
+		case *ast.ValueSpec:
+			tempInfo := info.TypeOf(y.Type)
+			if tempInfo != nil {
+				typeInfo = tempInfo
+			}
+		}
+
+	case *ast.BasicLit:
+		basic = x
+		typeInfo = info.TypeOf(x)
+
+		switch typeInfo {
+		case types.Typ[types.UntypedFloat], types.Typ[types.UntypedInt]:
+			// The post calls from astutil.Apply can be out of order,
+			// this guards against the case where the ast.BasicLit is inside an ast.UnaryExpr
+			// and the BasicLit gets evaluated before the UnaryExpr
+			if _, ok := cursor.Parent().(*ast.UnaryExpr); ok {
+				return nil
+			}
+		}
+
+	default:
+		return errors.New("Wrong node Type")
+	}
+
+	strValue := sign + basic.Value
+
+	switch typeInfo {
+	case types.Typ[types.Float32]:
+		fV, err := strconv.ParseFloat(strValue, 32)
+		if err != nil {
+			return err
+		}
+		call = genObfuscateFloat(float32(fV))
+	case types.Typ[types.Float64], types.Typ[types.UntypedFloat]:
+		fV, err := strconv.ParseFloat(strValue, 64)
+		if err != nil {
+			return err
+		}
+		call = genObfuscateFloat(fV)
+	}
+
+	if call != nil {
+		cursor.Replace(call)
+		return nil
+	}
+
+	intValue, err := strconv.ParseInt(strValue, 0, 64)
+	if err != nil {
+		return err
+	}
+
+	intType, ok := intTypes[typeInfo]
+	if !ok {
+		return errors.New("Wrong type")
+	}
+
+	call = genObfuscateInt(uint64(intValue), intType)
+
+	cursor.Replace(call)
+	return nil
+}
+
+func bytesToUint(bits int) ast.Expr {
+	bytes := bits / 8
+	bitsStr := strconv.Itoa(bits)
+
+	var expr ast.Expr
+	for i := 0; i < bytes; i++ {
+		posStr := strconv.Itoa(i)
+
+		if i == 0 {
+			expr = callExpr(ident("uint"+bitsStr), indexExpr("data", intLiteral(posStr)))
+			continue
+		}
+
+		shiftValue := strconv.Itoa(i * 8)
+		expr = &ast.BinaryExpr{
+			X:  expr,
+			Op: token.OR,
+			Y: &ast.BinaryExpr{
+				X:  callExpr(ident("uint"+bitsStr), indexExpr("data", intLiteral(posStr))),
+				Op: token.SHL,
+				Y:  intLiteral(shiftValue),
+			},
+		}
+	}
+
+	return expr
+}
+
+func genObfuscateInt(data uint64, typeInfo reflect.Type) *ast.CallExpr {
+	obfuscator := randObfuscator()
+	bitsize := typeInfo.Bits()
+
+	bitSizeStr := strconv.Itoa(bitsize)
+	byteSize := bitsize / 8
+	b := make([]byte, byteSize)
+
+	switch bitsize {
+	case 8:
+		b = []byte{uint8(data)}
+	case 16:
+		binary.LittleEndian.PutUint16(b, uint16(data))
+	case 32:
+		binary.LittleEndian.PutUint32(b, uint32(data))
+	case 64:
+		binary.LittleEndian.PutUint64(b, uint64(data))
+	default:
+		panic("data has the wrong length " + bitSizeStr)
+	}
+
+	block := obfuscator.obfuscate(b)
+	convertExpr := bytesToUint(bitsize)
+
+	block.List = append(block.List, boundsCheckData(byteSize-1), returnStmt(callExpr(ident(typeInfo.Name()), convertExpr)))
+
+	return lambdaCall(ident(typeInfo.Name()), block)
+}
+
+func uintToFloat(uintExpr *ast.CallExpr, typeStr string) *ast.CallExpr {
+	usesUnsafe = true
+	convert := &ast.StarExpr{
+		X: callExpr(
+			&ast.ParenExpr{
+				X: &ast.StarExpr{X: ident(typeStr)},
+			},
+			callExpr(
+				&ast.SelectorExpr{
+					X:   ident("unsafe"),
+					Sel: ident("Pointer"),
+				},
+				&ast.UnaryExpr{
+					Op: token.AND,
+					X:  ident("result"),
+				},
+			),
+		),
+	}
+
+	block := &ast.BlockStmt{List: []ast.Stmt{
+		&ast.AssignStmt{
+			Lhs: []ast.Expr{&ast.Ident{Name: "result"}},
+			Tok: token.DEFINE,
+			Rhs: []ast.Expr{uintExpr},
+		},
+		returnStmt(convert),
+	}}
+
+	return lambdaCall(ident(typeStr), block)
+}
+
+func genObfuscateFloat(data interface{}) *ast.CallExpr {
+	var (
+		b       uint64
+		typeStr string
+		intType reflect.Type
+	)
+
+	switch x := data.(type) {
+	case float32:
+		intType = intTypes[types.Typ[types.Uint32]]
+		typeStr = "float32"
+		b = uint64(math.Float32bits(x))
+	case float64:
+		intType = intTypes[types.Typ[types.Uint64]]
+		typeStr = "float64"
+		b = math.Float64bits(x)
+	default:
+		panic("data has the wrong type")
+	}
+
+	return uintToFloat(genObfuscateInt(b, intType), typeStr)
+}

--- a/internal/literals/xor.go
+++ b/internal/literals/xor.go
@@ -20,34 +20,28 @@ func (x xor) obfuscate(data []byte) *ast.BlockStmt {
 
 	return &ast.BlockStmt{List: []ast.Stmt{
 		&ast.AssignStmt{
-			Lhs: []ast.Expr{&ast.Ident{Name: "key"}},
+			Lhs: []ast.Expr{ident("key")},
 			Tok: token.DEFINE,
 			Rhs: []ast.Expr{dataToByteSlice(key)},
 		},
 		&ast.AssignStmt{
-			Lhs: []ast.Expr{&ast.Ident{Name: "data"}},
+			Lhs: []ast.Expr{ident("data")},
 			Tok: token.DEFINE,
 			Rhs: []ast.Expr{dataToByteSlice(data)},
 		},
 		&ast.RangeStmt{
-			Key:   &ast.Ident{Name: "i"},
-			Value: &ast.Ident{Name: "b"},
+			Key:   ident("i"),
+			Value: ident("b"),
 			Tok:   token.DEFINE,
-			X:     &ast.Ident{Name: "key"},
+			X:     ident("key"),
 			Body: &ast.BlockStmt{List: []ast.Stmt{
 				&ast.AssignStmt{
-					Lhs: []ast.Expr{&ast.IndexExpr{
-						X:     &ast.Ident{Name: "data"},
-						Index: &ast.Ident{Name: "i"},
-					}},
+					Lhs: []ast.Expr{indexExpr("data", ident("i"))},
 					Tok: token.ASSIGN,
 					Rhs: []ast.Expr{&ast.BinaryExpr{
-						X: &ast.IndexExpr{
-							X:     &ast.Ident{Name: "data"},
-							Index: &ast.Ident{Name: "i"},
-						},
+						X:  indexExpr("data", ident("i")),
 						Op: token.XOR,
-						Y:  &ast.Ident{Name: "b"},
+						Y:  ident("b"),
 					}},
 				},
 			}},

--- a/testdata/scripts/literals.txt
+++ b/testdata/scripts/literals.txt
@@ -1,13 +1,21 @@
-go run .
+go build
+exec ./main$exe
+binsubstr main$exe 'Lorem' 'dolor' 'second assign' 'First Line' 'Second Line' 'map value' 'to obfuscate' 'also obfuscate' 'stringTypeField String' 
+
+binsubint main$exe '-7081390804778629748' '-301627827188279046' '7679634459002713443'
+binsubfloat main$exe '3684433217126772357.33' '-9015867427900753906'
 cmp stderr main.stderr
 cp stderr normal.stderr
 garble -literals build
 exec ./main$exe
 cmp stderr main.stderr
 cmp stderr normal.stderr
-! binsubstr main$exe 'garbleDecrypt' 'Lorem' 'ipsum' 'dolor' 'first assign' 'second assign' 'First Line' 'Second Line' 'map value' 'to obfuscate' 'also obfuscate' 'stringTypeField String' 'stringTypeStruct'
+! binsubstr main$exe 'garbleDecrypt' 'Lorem' 'dolor' 'first assign' 'second assign' 'First Line' 'Second Line' 'map value' 'to obfuscate' 'also obfuscate' 'stringTypeField String' 
 
-binsubstr main$exe 'also skip this' 'skip typed const' 'skip typed var' 'skip typed var assign' 'stringTypeField strType' 'stringType lambda func return' 'testMap1 key' 'testMap2 key' 'testMap3 key' 'testMap1 value' 'testMap3 value' 'testMap1 new value' 'testMap3 new value' 'stringType func param' 'stringType return' 'skip untyped const'
+binsubstr main$exe 'Skip this block' 'also skip this' 'skip typed const' 'skip typed var' 'skip typed var assign' 'stringTypeField strType' 'stringType lambda func return' 'testMap1 key' 'testMap2 key' 'testMap3 key' 'testMap1 value' 'testMap3 value' 'testMap1 new value' 'testMap3 new value' 'stringType func param' 'stringType return' 'skip untyped const'
+
+! binsubint main$exe '-7081390804778629748' '-301627827188279046' '7679634459002713443'
+! binsubfloat main$exe '3684433217126772357.33' '-9015867427900753906'
 [short] stop # checking that the build is reproducible is slow
 
 # Also check that the binary is reproducible.
@@ -35,6 +43,8 @@ Second Line`
 const (
 	i       = 1
 	boolean = true
+
+	skip1 = "Skip this block"
 )
 
 const (
@@ -82,11 +92,13 @@ func main() {
 	testMap["map key"] = "new value"
 	println(testMap["map key"])
 	println("another literal")
-	println(skip2)
+	println(skip1, skip2)
 	println(i, foo, bar)
 	typedTest()
 	constantTest()
 	byteTest()
+	numTest()
+	boolTest()
 }
 
 type stringType string
@@ -196,6 +208,80 @@ func stringTypeFunc(s stringType) stringType {
 	return "stringType return" // skip
 }
 
+func numTest() {
+	const a = 1 // skip
+
+	const b = a + 2 // skip
+
+	const c = 2824583991413579605
+
+	d := 4
+
+	var e = 5
+
+	var f int
+	f = 3735714531481032066
+
+	println(a, b, c, d, e, f)
+
+	var (
+		untypedInt       = -7081390804778629760 + 12
+		intVar     int   = -301627827188279046
+		int8Var    int8  = -122.0
+		int16Var   int16 = 3534
+		int32Var   int32 = 333453534
+		int64Var   int64 = 4568766098255857483
+
+		uintVar    uint    = 7679634459002713443
+		uint8Var   uint8   = 34
+		uint16Var  uint16  = 3534
+		uint32Var  uint32  = 333453534
+		uint64Var  uint64  = 5490982829161518439
+		uintptrVar uintptr = 7364326871810921708
+
+		untypedFloat         = 3684433217126772357.33
+		floatVar     float64 = -9015867427900753906
+		floatVar32   float32 = 6338507605633
+
+		complexVar64  complex64  = -435453453534 // skip
+		complexVar128 complex128 = 1 + 4i        // skip
+
+		underscoreInt   = 1_3_3_7
+		underscoreFloat = 1_3_3_7.0
+
+		hexInt   = 0x1337   // skip
+		hexFloat = 0x1337p0 // skip
+
+		octalInt   = 0o1337 // skip
+		octalFloat = 0o1337 // skip
+	)
+
+	floatShort := -435453453534.0
+	println(untypedInt, intVar, int8Var, int16Var, int32Var, int64Var)
+	println(uintVar, uint8Var, uint16Var, uint32Var, uint64Var, uintptrVar)
+	println(untypedFloat, floatVar, floatShort, floatVar32)
+	println(complexVar64, complexVar128)
+	println(underscoreInt, underscoreFloat, hexInt, hexFloat, octalInt, octalFloat)
+
+}
+
+func boolTest() {
+	const a = true // skip
+
+	const b = false == a // skip
+
+	const c bool = false
+
+	d := true
+
+	var e = true
+
+	var f bool
+	f = false
+
+	println(a, b, c, d, e, f)
+}
+
 -- main.stderr --
 Lorem true
 First Line
@@ -207,7 +293,7 @@ second assign
 to obfuscate also obfuscate
 new value
 another literal
-also skip this
+Skip this block also skip this
 1 0 1
 skip untyped const
 skip typed const skip typed var skip typed var assign
@@ -222,3 +308,10 @@ foo
 12, 13, 
 12, 13, 
 12, 13, 0, 0, 
+1 3 2824583991413579605 4 5 3735714531481032066
+-7081390804778629748 -301627827188279046 -122 3534 333453534 4568766098255857483
+7679634459002713443 34 3534 333453534 5490982829161518439 7364326871810921708
++3.684433e+018 -9.015867e+018 -4.354535e+011 +6.338508e+012
+(-4.354535e+011+0.000000e+000i) (+1.000000e+000+4.000000e+000i)
+1337 +1.337000e+003 4919 +4.919000e+003 735 735
+true false false true true false


### PR DESCRIPTION
Add ast helper functions to reduce ast footprint.