### PR TITLE
internal/literals: minor adjustments to the last commits

### DIFF
--- a/internal/literals/literals.go
+++ b/internal/literals/literals.go
@@ -25,7 +25,6 @@ func randObfuscator() obfuscator {
 // Obfuscate replace literals with obfuscated lambda functions
 func Obfuscate(files []*ast.File, info *types.Info, fset *token.FileSet, blacklist map[types.Object]struct{}) []*ast.File {
 	pre := func(cursor *astutil.Cursor) bool {
-
 		switch x := cursor.Node().(type) {
 		case *ast.GenDecl:
 			if x.Tok != token.CONST {

--- a/internal/literals/obfuscators.go
+++ b/internal/literals/obfuscators.go
@@ -56,18 +56,10 @@ func genRandBytes(buffer []byte) {
 	}
 }
 
-func genRandInt() int {
-	return mathrand.Int()
-}
-
-func genRandIntn(max int) int {
-	return mathrand.Intn(max)
-}
-
-func generateIntSlice(max, count int) []int {
+func genRandIntSlice(max, count int) []int {
 	indexes := make([]int, count)
 	for i := 0; i < count; i++ {
-		indexes[i] = genRandIntn(max)
+		indexes[i] = mathrand.Intn(max)
 	}
 	return indexes
 }

--- a/main_test.go
+++ b/main_test.go
@@ -131,6 +131,7 @@ func readFile(ts *testscript.TestScript, file string) string {
 	cachedBinary.content = ts.ReadFile(file)
 	return cachedBinary.content
 }
+
 func binsubstr(ts *testscript.TestScript, neg bool, args []string) {
 	if len(args) < 2 {
 		ts.Fatalf("usage: binsubstr file substr...")


### PR DESCRIPTION
First, unindent some of the AST code.

Second, genRandInt is unused; delete it.

Third, genRandIntn is really just mathrand.Intn. Just use it directly.

Fourth, don't use inline comments if they result in super long lines.