### PR TITLE
Add split obfuscator

### DIFF
--- a/internal/literals/obfuscators.go
+++ b/internal/literals/obfuscators.go
@@ -19,6 +19,7 @@ var (
 	obfuscators = []obfuscator{
 		xor{},
 		swap{},
+		split{},
 	}
 	envGarbleSeed = os.Getenv("GARBLE_SEED")
 )

--- a/internal/literals/split.go
+++ b/internal/literals/split.go
@@ -12,6 +12,8 @@ const (
 	minCaseCount = 3
 )
 
+// Split obfuscator splits data into chunks of random length and shuffles them,
+// then encrypts them using xor.
 type split struct{}
 
 // check that the obfuscator interface is implemented

--- a/internal/literals/split.go
+++ b/internal/literals/split.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	maxChunkSize = 4
+	maxChunkSize = 5
 	minCaseCount = 3
 )
 
@@ -26,7 +26,7 @@ func splitIntoRandomChunks(data []byte) [][]byte {
 
 	var chunks [][]byte
 	for len(data) > 0 {
-		chunkSize := 1 + mathrand.Intn(maxChunkSize)
+		chunkSize := 1 + mathrand.Intn(maxChunkSize-1)
 		if chunkSize > len(data) {
 			chunkSize = len(data)
 		}

--- a/testdata/scripts/literals.txt
+++ b/testdata/scripts/literals.txt
@@ -42,7 +42,7 @@ grep '^\s+\w+\[\w+\] = \w+\[\w+\] \^ \w+$' .obf-src/main/z0.go
 # Swap obfuscator. Detect [...]byte|uint16|uint32|uint64{...}
 grep '^\s+\w+ := \[\.{3}\](byte|uint16|uint32|uint64)\{[0-9\s,]+\}$' .obf-src/main/z0.go
 
-# Split obfuscator. Detect decryptKey ^= i *- counter
+# Split obfuscator. Detect decryptKey ^= i * counter
 grep '^\s+\w+ \^= \w+ \* \w+$' .obf-src/main/z0.go
 
 

--- a/testdata/scripts/literals.txt
+++ b/testdata/scripts/literals.txt
@@ -42,6 +42,9 @@ grep '^\s+\w+\[\w+\] = \w+\[\w+\] \^ \w+$' .obf-src/main/z0.go
 # Swap obfuscator. Detect [...]byte|uint16|uint32|uint64{...}
 grep '^\s+\w+ := \[\.{3}\](byte|uint16|uint32|uint64)\{[0-9\s,]+\}$' .obf-src/main/z0.go
 
+# Split obfuscator. Detect decryptKey ^= i *- counter
+grep '^\s+\w+ \^= \w+ \* \w+$' .obf-src/main/z0.go
+
 
 -- go.mod --
 module test/main


### PR DESCRIPTION
Original: 

```go
package main

func main() {
	println("Hello world")
}
```

Obfuscated:
```go
package main

func main() {
	println(func() string {
		var data []byte
		i := 7
		decryptKey := 6716507299667048735
		for counter := 0; i != 9; counter++ {
			decryptKey ^= i * counter
			switch i {
			case 7:
				i = 3
				data = append(data, 110)
			case 3:
				data = append(data, 67)
				i = 2
			case 6:
				i = 12
				data = append(data, 6)
			case 11:
				i = 5
				data = append(data, 73)
			case 4:
				i = 0
				data = append(data, 74)
			case 10:
				i = 8
				data = append(data, 74)
			case 5:
				data = append(data, 84)
				i = 10
			case 0:
				i = 6
				data = append(data, 73)
			case 1:
				i = 9
				for y := range data {
					data[y] ^= byte(decryptKey)
				}
			case 8:
				data = append(data, 66)
				i = 1
			case 2:
				data = append(data, 74)
				i = 4
			case 12:
				data = append(data, 81)
				i = 11
			}
		}
		return string(data)
	}())
}
```

Long strings are divided into chunks of size from 1 to `maxChunkSize`.