### PR TITLE
Add xor2 obfuscator

### DIFF
--- a/internal/literals/obfuscators.go
+++ b/internal/literals/obfuscators.go
@@ -20,7 +20,7 @@ var (
 		xor{},
 		swap{},
 		split{},
-		xor2{},
+		xorShuffle{},
 	}
 	envGarbleSeed = os.Getenv("GARBLE_SEED")
 )

--- a/internal/literals/obfuscators.go
+++ b/internal/literals/obfuscators.go
@@ -20,6 +20,7 @@ var (
 		xor{},
 		swap{},
 		split{},
+		xor2{},
 	}
 	envGarbleSeed = os.Getenv("GARBLE_SEED")
 )

--- a/internal/literals/xor2.go
+++ b/internal/literals/xor2.go
@@ -17,17 +17,16 @@ func (x xor2) obfuscate(data []byte) *ast.BlockStmt {
 	key := make([]byte, len(data))
 	genRandBytes(key)
 
-	fullData := make([]byte, len(data))
+	fullData := make([]byte, len(data)+len(key))
 	for i, b := range key {
-		fullData[i] = data[i] ^ b
+		fullData[i], fullData[i+len(data)] = data[i]^b, b
 	}
-	fullData = append(fullData, key...)
 
 	shuffledIdxs := mathrand.Perm(len(fullData))
 
 	shuffledFullData := make([]byte, len(fullData))
-	for i := range fullData {
-		shuffledFullData[shuffledIdxs[i]] = fullData[i]
+	for i, b := range fullData {
+		shuffledFullData[shuffledIdxs[i]] = b
 	}
 
 	args := []ast.Expr{ah.Ident("data")}
@@ -39,7 +38,7 @@ func (x xor2) obfuscate(data []byte) *ast.BlockStmt {
 		})
 	}
 
-	return &ast.BlockStmt{List: []ast.Stmt{
+	return ah.BlockStmt(
 		&ast.AssignStmt{
 			Lhs: []ast.Expr{ah.Ident("fullData")},
 			Tok: token.DEFINE,
@@ -59,5 +58,5 @@ func (x xor2) obfuscate(data []byte) *ast.BlockStmt {
 			Tok: token.ASSIGN,
 			Rhs: []ast.Expr{ah.CallExpr(ah.Ident("append"), args...)},
 		},
-	}}
+	)
 }

--- a/internal/literals/xor2.go
+++ b/internal/literals/xor2.go
@@ -1,0 +1,63 @@
+package literals
+
+import (
+	"go/ast"
+	"go/token"
+	mathrand "math/rand"
+
+	ah "mvdan.cc/garble/internal/asthelper"
+)
+
+type xor2 struct{}
+
+// check that the obfuscator interface is implemented
+var _ obfuscator = xor2{}
+
+func (x xor2) obfuscate(data []byte) *ast.BlockStmt {
+	key := make([]byte, len(data))
+	genRandBytes(key)
+
+	fullData := make([]byte, len(data))
+	for i, b := range key {
+		fullData[i] = data[i] ^ b
+	}
+	fullData = append(fullData, key...)
+
+	shuffledIdxs := mathrand.Perm(len(fullData))
+
+	shuffledFullData := make([]byte, len(fullData))
+	for i := range fullData {
+		shuffledFullData[shuffledIdxs[i]] = fullData[i]
+	}
+
+	args := []ast.Expr{ah.Ident("data")}
+	for i := range data {
+		args = append(args, &ast.BinaryExpr{
+			X:  ah.IndexExpr("fullData", ah.IntLit(shuffledIdxs[i])),
+			Op: token.XOR,
+			Y:  ah.IndexExpr("fullData", ah.IntLit(shuffledIdxs[len(data)+i])),
+		})
+	}
+
+	return &ast.BlockStmt{List: []ast.Stmt{
+		&ast.AssignStmt{
+			Lhs: []ast.Expr{ah.Ident("fullData")},
+			Tok: token.DEFINE,
+			Rhs: []ast.Expr{ah.DataToByteSlice(shuffledFullData)},
+		},
+		&ast.DeclStmt{
+			Decl: &ast.GenDecl{
+				Tok: token.VAR,
+				Specs: []ast.Spec{&ast.ValueSpec{
+					Names: []*ast.Ident{ah.Ident("data")},
+					Type:  &ast.ArrayType{Elt: ah.Ident("byte")},
+				}},
+			},
+		},
+		&ast.AssignStmt{
+			Lhs: []ast.Expr{ah.Ident("data")},
+			Tok: token.ASSIGN,
+			Rhs: []ast.Expr{ah.CallExpr(ah.Ident("append"), args...)},
+		},
+	}}
+}

--- a/internal/literals/xor_shuffle.go
+++ b/internal/literals/xor_shuffle.go
@@ -8,12 +8,12 @@ import (
 	ah "mvdan.cc/garble/internal/asthelper"
 )
 
-type xor2 struct{}
+type xorShuffle struct{}
 
 // check that the obfuscator interface is implemented
-var _ obfuscator = xor2{}
+var _ obfuscator = xorShuffle{}
 
-func (x xor2) obfuscate(data []byte) *ast.BlockStmt {
+func (x xorShuffle) obfuscate(data []byte) *ast.BlockStmt {
 	key := make([]byte, len(data))
 	genRandBytes(key)
 

--- a/testdata/scripts/literals.txt
+++ b/testdata/scripts/literals.txt
@@ -45,6 +45,9 @@ grep '^\s+\w+ := \[\.{3}\](byte|uint16|uint32|uint64)\{[0-9\s,]+\}$' .obf-src/ma
 # Split obfuscator. Detect decryptKey ^= i * counter
 grep '^\s+\w+ \^= \w+ \* \w+$' .obf-src/main/z0.go
 
+# Xor2 obfuscator. Detect data = append(data, x ^ y...)
+grep '^\s+\w+ = append\(\w+,(\s+\w+\[\d+\]\^\w+\[\d+\],?)+\)$' .obf-src/main/z0.go
+
 
 -- go.mod --
 module test/main

--- a/testdata/scripts/literals.txt
+++ b/testdata/scripts/literals.txt
@@ -45,7 +45,7 @@ grep '^\s+\w+ := \[\.{3}\](byte|uint16|uint32|uint64)\{[0-9\s,]+\}$' .obf-src/ma
 # Split obfuscator. Detect decryptKey ^= i * counter
 grep '^\s+\w+ \^= \w+ \* \w+$' .obf-src/main/z0.go
 
-# Xor2 obfuscator. Detect data = append(data, x ^ y...)
+# XorShuffle obfuscator. Detect data = append(data, x ^ y...)
 grep '^\s+\w+ = append\(\w+,(\s+\w+\[\d+\]\^\w+\[\d+\],?)+\)$' .obf-src/main/z0.go
 
 


### PR DESCRIPTION
Continuation of the [matrix ](https://github.com/mvdan/garble/issues/73#issuecomment-665310590)obfuscator idea, an example of a result:
```go
package main

func main() {
	println(func() string {
		fullData := []byte("\x1a&1\x8eB\xbe\xefј\xae\x0204oyXUf-Jh\x03")
		var data []byte
		data = append(data, fullData[14]^fullData[2], fullData[11]^fullData[16], fullData[1]^fullData[19], fullData[12]^fullData[15], fullData[7]^fullData[5], fullData[9]^fullData[3], fullData[6]^fullData[8], fullData[18]^fullData[4], fullData[20]^fullData[0], fullData[13]^fullData[21], fullData[10]^fullData[17])
		return string(data)
	}())
}
```

P.s. It's a temporary name, waiting for suggestions.