### PR TITLE
keep build flags when calling 'go list'

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -354,6 +354,11 @@ func TestSplitFlagsFromArgs(t *testing.T) {
 			[]string{"-race", "pkg"},
 			[2][]string{{"-race"}, {"pkg"}},
 		},
+		{
+			"ExplicitBoolFlag",
+			[]string{"-race=true", "pkg"},
+			[2][]string{{"-race=true"}, {"pkg"}},
+		},
 	}
 	for _, test := range tests {
 		test := test
@@ -364,6 +369,38 @@ func TestSplitFlagsFromArgs(t *testing.T) {
 
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Fatalf("splitFlagsFromArgs(%q) mismatch (-want +got):\n%s", test.args, diff)
+			}
+		})
+	}
+}
+
+func TestFilterBuildFlags(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		flags []string
+		want  []string
+	}{
+		{"Empty", []string{}, nil},
+		{
+			"NoBuild",
+			[]string{"-short", "-json"},
+			nil,
+		},
+		{
+			"Mixed",
+			[]string{"-short", "-tags", "foo", "-mod=readonly", "-json"},
+			[]string{"-tags", "foo", "-mod=readonly"},
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			got := filterBuildFlags(test.flags)
+
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Fatalf("filterBuildFlags(%q) mismatch (-want +got):\n%s", test.flags, diff)
 			}
 		})
 	}

--- a/testdata/scripts/imports.txt
+++ b/testdata/scripts/imports.txt
@@ -1,4 +1,4 @@
-garble build
+garble build -tags buildtag
 exec ./main
 cmp stdout main.stdout
 
@@ -9,10 +9,10 @@ cmp stdout main.stdout
 # Also check that the binary is reproducible when many imports are involved.
 cp main$exe main_old$exe
 rm main$exe
-garble build
+garble build -tags buildtag
 bincmp main$exe main_old$exe
 
-go build
+go build -tags buildtag
 exec ./main
 cmp stdout main.stdout
 
@@ -55,6 +55,20 @@ func main() {
 	linkedPrintln(nil)
 	fmt.Println(quote.Go())
 }
+-- notag_fail.go --
+// +build !buildtag
+
+package main
+
+var foo int = "should be omitted by -tags"
+-- withtag_success.go --
+// +build buildtag
+
+package main
+
+import "fmt"
+
+func init() { fmt.Println("buildtag init func") }
 -- imported/imported.go --
 package imported
 
@@ -92,6 +106,7 @@ var _ = reflect.TypeOf(ReflectValueOfVar)
 type ImportedType int
 
 -- main.stdout --
+buildtag init func
 imported var value
 imported const value
 x


### PR DESCRIPTION
Otherwise any build flags like -tags won't be used, and we might easily
end up with errors or incorrect packages.

The common case with -tags is covered by one of the integration test
scripts. On top of that, we add a table-driven unit test to cover all
edge cases, since there are many we can do quickly in a unit test.

Fixes #82.