### PR TITLE
always use the compiler's -dwarf=false flag

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,10 @@
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 name: Test
 jobs:
   test:


### PR DESCRIPTION
First, our original append line was completely ineffective; we never
used that "flags" slice again. Second, we only attempted to use the flag
when we obfuscated a package.

In fact, we never care about debugging information here, so for any
package we compile, we can add "-dwarf=false". At the moment, we compile
all packages, even if they aren't to be obfuscated, due to the lack of
access to the build cache.

As such, we save a significant amount of work. The numbers below were
obtained on a quiet machine with "go test -bench=. -benchtime=10x", six
times before and after the change.

	name     old time/op       new time/op       delta
	Build-8        2.06s ± 4%        1.87s ± 2%  -9.21%  (p=0.002 n=6+6)

	name     old sys-time/op   new sys-time/op   delta
	Build-8        1.51s ± 2%        1.46s ± 1%  -3.12%  (p=0.004 n=6+5)

	name     old user-time/op  new user-time/op  delta
	Build-8        11.9s ± 2%        10.8s ± 1%  -8.71%  (p=0.002 n=6+6)

While at it, only do CI builds on pushes and PRs to the master branch,
so that my PRs created from the same repo don't trigger duplicate
builds.