### PR TITLE
Fix reflect detection if -literals is passed.

### DIFF
--- a/main.go
+++ b/main.go
@@ -450,11 +450,6 @@ func transformCompile(args []string) ([]string, error) {
 
 	if envGarbleLiterals {
 		files = literals.Obfuscate(files, info, fset, blacklist)
-		// ast changed so we need to typecheck again
-		pkg, err = origTypesConfig.Check(pkgPath, fset, files, info)
-		if err != nil {
-			return nil, fmt.Errorf("typecheck error: %v", err)
-		}
 	}
 
 	tempDir, err := ioutil.TempDir("", "garble-build")

--- a/testdata/scripts/imports.txt
+++ b/testdata/scripts/imports.txt
@@ -16,6 +16,11 @@ go build -tags buildtag
 exec ./main
 cmp stdout main.stdout
 
+# Also check that -literals doesn't break anything
+garble -literals build -tags buildtag
+exec ./main
+cmp stdout main.stdout
+
 -- go.mod --
 module test/main
 -- main.go --


### PR DESCRIPTION
Fixes #93.

The second typecheck lead to the creation of different type objects,
which didn't match the types in the blacklist anymore.

It turns out we don't need the second typecheck,
therfore it is now removed.