### PR TITLE
various minor cleanups and fixes

### DIFF
--- a/internal/literals/numbers.go
+++ b/internal/literals/numbers.go
@@ -76,7 +76,7 @@ func obfuscateNumberLiteral(cursor *astutil.Cursor, info *types.Info) error {
 		}
 
 	default:
-		return errors.New("Wrong node Type")
+		return errors.New("wrong node Type")
 	}
 
 	strValue := sign + basic.Value
@@ -108,7 +108,7 @@ func obfuscateNumberLiteral(cursor *astutil.Cursor, info *types.Info) error {
 
 	intType, ok := intTypes[typeInfo]
 	if !ok {
-		return errors.New("Wrong type")
+		return errors.New("wrong type")
 	}
 
 	call = genObfuscateInt(uint64(intValue), intType)

--- a/main.go
+++ b/main.go
@@ -225,6 +225,8 @@ func main1() int {
 }
 
 func mainErr(args []string) error {
+	// TODO(mvdan): only run this once at the very beginning, then set the
+	// GOPRIVATE env var.
 	out, err := exec.Command("go", "env", "GOPRIVATE").CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("%v: %s", err, out)
@@ -257,7 +259,7 @@ func mainErr(args []string) error {
 			seed = make([]byte, 16) // random 128 bit seed
 
 			if _, err := rand.Read(seed); err != nil {
-				return fmt.Errorf("Error generating random seed: %v", err)
+				return fmt.Errorf("error generating random seed: %v", err)
 			}
 
 			flagSeed = "random;" + base64.StdEncoding.EncodeToString(seed)
@@ -433,7 +435,7 @@ func transformCompile(args []string) ([]string, error) {
 	if envGarbleSeed != "" {
 		seed, err = base64.StdEncoding.DecodeString(strings.TrimPrefix(envGarbleSeed, "random;"))
 		if err != nil {
-			return nil, fmt.Errorf("Error decoding base64 encoded seed: %v", err)
+			return nil, fmt.Errorf("error decoding base64 seed: %v", err)
 		}
 
 		mathrand.Seed(int64(binary.BigEndian.Uint64(seed)))

--- a/testdata/scripts/plugin.txt
+++ b/testdata/scripts/plugin.txt
@@ -9,7 +9,6 @@ go build -trimpath
 exec ./main
 cmp stderr main.stderr
 binsubstr main$exe 'PublicVar' 'PublicFunc'
-! binsubstr plugin.so 'privateFunc'
 
 [short] stop # no need to verify this with -short
 

--- a/testdata/scripts/seed.txt
+++ b/testdata/scripts/seed.txt
@@ -1,8 +1,8 @@
 # Check the binary with a given base64 encoded seed
 garble -literals -seed=OQg9kACEECQ= build
 exec ./main$exe
-cmp stderr main.stdout   
-! binsubstr  main$exe 'teststring' 'teststringVar' 'imported var value' 'ImportedVar'
+cmp stderr main.stdout
+! binsubstr main$exe 'teststring' 'teststringVar' 'imported var value' 'ImportedVar'
 
 [short] stop # checking that the build is reproducible and random is slow
 
@@ -22,7 +22,7 @@ garble -literals -seed=NruiDmVz6/s= build
 garble -literals -seed=random build
 exec ./main$exe
 cmp stderr main.stdout
-! binsubstr  main$exe 'teststring' 'teststringVar' 'imported var value' 'ImportedVar'
+! binsubstr main$exe 'teststring' 'teststringVar' 'imported var value' 'ImportedVar'
 
 # Also check that the random binary is not reproducible.
 cp main$exe main_old$exe

--- a/testdata/scripts/syntax.txt
+++ b/testdata/scripts/syntax.txt
@@ -2,7 +2,7 @@ go build
 exec ./main$exe
 cmp stderr main.stderr
 
-binsubstr main$exe 'globalVar' # 'globalType' only matches on go < 1.15 
+binsubstr main$exe 'globalVar' # 'globalType' only matches on go < 1.15
 ! binsubstr main$exe 'localName' 'globalConst'
 
 garble -debugdir=debug build


### PR DESCRIPTION
Error strings should never be capitalized.

A binsubstr line in one of the tests was duplicate and thus useless.

Remove duplicate or trailing spaces in test scripts.

Finally, add a TODO for an optimization I just spotted.