### PR TITLE
testdata: set GOPRIVATE in all but two tests

### DIFF
--- a/testdata/scripts/asm.txt
+++ b/testdata/scripts/asm.txt
@@ -1,3 +1,5 @@
+env GOPRIVATE=test/main
+
 garble build
 exec ./main
 cmp stderr main.stderr

--- a/testdata/scripts/basic.txt
+++ b/testdata/scripts/basic.txt
@@ -2,7 +2,7 @@
 ! exec go build -a -toolexec=garble main.go
 stderr 'should be used alongside -trimpath'
 
-# Check that the simplest use of garble works.
+# Check that the simplest use of garble works. Note the lack of a module or GOPRIVATE.
 garble build main.go
 exec ./main
 cmp stderr main.stderr

--- a/testdata/scripts/cgo.txt
+++ b/testdata/scripts/cgo.txt
@@ -1,3 +1,5 @@
+env GOPRIVATE=test/main
+
 garble build
 exec ./main
 cmp stderr main.stderr

--- a/testdata/scripts/debugdir.txt
+++ b/testdata/scripts/debugdir.txt
@@ -1,14 +1,16 @@
+env GOPRIVATE=test/main
+
 garble -debugdir ./test1 build
-exists 'test1/test/imported/imported.go' 'test1/main/main.go'
-! grep ImportedFunc $WORK/test1/test/imported/imported.go
+exists 'test1/test/main/imported/imported.go' 'test1/main/main.go'
+! grep ImportedFunc $WORK/test1/test/main/imported/imported.go
 ! grep ImportedFunc $WORK/test1/main/main.go
 
 -- go.mod --
-module test
+module test/main
 -- main.go --
 package main
 
-import "test/imported"
+import "test/main/imported"
 
 func main() {
 	imported.ImportedFunc()

--- a/testdata/scripts/implement.txt
+++ b/testdata/scripts/implement.txt
@@ -1,3 +1,5 @@
+env GOPRIVATE=test/main
+
 garble build
 exec ./main
 cmp stderr main.stderr

--- a/testdata/scripts/imports.txt
+++ b/testdata/scripts/imports.txt
@@ -1,3 +1,6 @@
+# Note that this is the only test with a module where we rely on the detection
+# of GOPRIVATE.
+
 garble build -tags buildtag
 exec ./main
 cmp stdout main.stdout

--- a/testdata/scripts/ldflags.txt
+++ b/testdata/scripts/ldflags.txt
@@ -1,3 +1,6 @@
+# Note the proper domain, since the dot adds an edge case.
+env GOPRIVATE=domain.test/main
+
 garble build -ldflags='-X=main.unexportedVersion=v1.0.0 -X=domain.test/main/imported.ExportedVar=replaced'
 exec ./main
 cmp stderr main.stderr

--- a/testdata/scripts/literals.txt
+++ b/testdata/scripts/literals.txt
@@ -1,3 +1,5 @@
+env GOPRIVATE=test/main
+
 # Generate and write random literals into a separate file
 generate-literals extraLiterals.go 500 printExtraLiterals
 

--- a/testdata/scripts/modinfo.txt
+++ b/testdata/scripts/modinfo.txt
@@ -1,3 +1,5 @@
+env GOPRIVATE=test/main
+
 garble build
 exec ./main
 cmp stderr main.stderr

--- a/testdata/scripts/panic.txt
+++ b/testdata/scripts/panic.txt
@@ -1,3 +1,5 @@
+env GOPRIVATE=test/main
+
 garble build
 ! exec ./main
 cmp stderr main.stderr

--- a/testdata/scripts/plugin.txt
+++ b/testdata/scripts/plugin.txt
@@ -1,5 +1,7 @@
 [windows] skip 'Go plugins are not supported on Windows'
 
+env GOPRIVATE=test/main
+
 garble build -buildmode=plugin ./plugin
 binsubstr plugin.so 'PublicVar' 'PublicFunc'
 ! binsubstr plugin.so 'privateFunc'

--- a/testdata/scripts/seed.txt
+++ b/testdata/scripts/seed.txt
@@ -1,3 +1,5 @@
+env GOPRIVATE=test/main
+
 # Check the binary with a given base64 encoded seed
 garble -literals -seed=OQg9kACEECQ= build
 exec ./main$exe

--- a/testdata/scripts/syntax.txt
+++ b/testdata/scripts/syntax.txt
@@ -1,9 +1,4 @@
-go build
-exec ./main$exe
-cmp stderr main.stderr
-
-binsubstr main$exe 'globalVar' # 'globalType' only matches on go < 1.15
-! binsubstr main$exe 'localName' 'globalConst'
+env GOPRIVATE=test/main
 
 garble -debugdir=debug build
 exec ./main$exe
@@ -12,6 +7,16 @@ cmp stderr main.stderr
 ! binsubstr main$exe 'localName' 'globalConst' 'globalVar' 'globalType' 'valuable information'
 
 binsubstr debug/main/scopes.go 'localName' 'globalConst'
+
+[short] stop # no need to verify this with -short
+
+go build
+exec ./main$exe
+cmp stderr main.stderr
+
+binsubstr main$exe 'globalVar' # 'globalType' only matches on go < 1.15
+! binsubstr main$exe 'localName' 'globalConst'
+
 
 -- go.mod --
 module test/main

--- a/testdata/scripts/test.txt
+++ b/testdata/scripts/test.txt
@@ -1,3 +1,6 @@
+# Note that we need bar_test too.
+env GOPRIVATE=test/bar,test/bar_test
+
 # build the test binary
 garble test -c
 binsubstr bar.test$exe 'TestFoo' 'TestSeparateFoo'

--- a/testdata/scripts/tiny.txt
+++ b/testdata/scripts/tiny.txt
@@ -1,3 +1,5 @@
+env GOPRIVATE=test/main
+
 env TINY_PATTERN='^\/\/line :1$'
 env DEFAULT_PATTERN='^\/\/line \w\.go:[1-9][0-9]*$'
 env DEFAULT_STACK_PATTERN='^\t\w\.go:[1-9][0-9]*(\s\+0x[0-9a-f]+)?'
@@ -32,7 +34,7 @@ grep $DEFAULT_PATTERN .obf-src/main/main.go
 stderr $DEFAULT_STACK_PATTERN
 
 -- go.mod --
-module main
+module test/main
 -- main.go --
 package main
 


### PR DESCRIPTION
basic.txt just builds main.go without a module. Similarly, we leave
imports.txt without a GOPRIVATE, to test the 'go list -m' fallback.

For all other tests, explicitly set GOPRIVATE, to avoid two exec calls -
both 'go env GOPRIVATE' as well as 'go list -m'. Each of those calls
takes in the order of 10ms, so saving ~26 exec calls should easily add
to 200-300ms saved from 'go test -short'.