### PR TITLE
complain when GOPRIVATE matches no packages

### DIFF
--- a/testdata/scripts/goprivate.txt
+++ b/testdata/scripts/goprivate.txt
@@ -1,0 +1,16 @@
+env GOPRIVATE=match-absolutely/nothing
+! garble build -o bin ./standalone
+stderr 'does not match any packages'
+
+[short] stop
+
+# TODO: https://github.com/mvdan/garble/issues/108
+# env GOPRIVATE='*'
+# garble build  -o bin ./standalone
+
+-- go.mod --
+module test/main
+-- standalone/main.go --
+package main
+
+func main() {}


### PR DESCRIPTION
This is important, because it would mean that we would obfuscate
nothing. At best, it would be confusing; at worst, it could mislead
the user into thinking the binary is obfuscated.

Fixes #20.
Updates #108.