### PR TITLE
never obfuscate unsafe.Pointer

### DIFF
--- a/main.go
+++ b/main.go
@@ -469,6 +469,10 @@ func transformCompile(args []string) ([]string, error) {
 
 	blacklist := buildBlacklist(files, info, pkg)
 
+	// unsafe.Pointer is a special type that doesn't exist as a plain Go
+	// type definition, so we can't change its name.
+	blacklist[types.Unsafe.Scope().Lookup("Pointer")] = struct{}{}
+
 	if envGarbleLiterals {
 		files = literals.Obfuscate(files, info, fset, blacklist)
 	}


### PR DESCRIPTION
Before this change, obfuscating any package using unsafe.Pointer and
with GOPRIVATE="*" would result in errors like:

	undefined: unsafe.ZrMmYd1lg

This is because the type isn't plain Go; it's rather a special type that
gets special treatment from the typechecker and compiler:

	type Pointer *ArbitraryType

So, trying to obfuscate the name "unsafe.Pointer" will never work,
because there isn't a real Go type definition we can obfuscate along
with that.

Updates, but does not yet fully fix, #108.