### PR TITLE
Obfuscate import paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The tool wraps calls to the Go compiler and linker to transform the Go build, in
 order to:
 
 * Replace as many useful identifiers as possible with short base64 hashes
+* Replace package paths with short base64 hashes
 * Remove all [build](https://golang.org/pkg/runtime/#Version) and [module](https://golang.org/pkg/runtime/debug/#ReadBuildInfo) information
 * Strip filenames and shuffle position information
 * Obfuscate literals, if the `-literals` flag is given
@@ -42,9 +43,6 @@ packages to garble, set `GOPRIVATE`, documented at `go help module-private`.
 
 Most of these can improve with time and effort. The purpose of this section is
 to document the current shortcomings of this tool.
-
-* Package import path names are never garbled, since we require the original
-  paths for the build system to work. See #13 to investigate alternatives.
 
 * The `-a` flag for `go build` is required, since `-toolexec` doesn't work well
   with the build cache; see [golang/go#27628](https://github.com/golang/go/issues/27628).

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module mvdan.cc/garble
 
 go 1.14
 
+replace github.com/Binject/debug => /home/capnspacehook/go/src/github.com/Binject/debug
+
 require (
+	github.com/Binject/debug v0.0.0-20200725165605-6aefc612bb56
 	github.com/google/go-cmp v0.5.1
 	github.com/rogpeppe/go-internal v1.6.0
 	golang.org/x/tools v0.0.0-20200622203043-20e05c1c8ffa

--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,8 @@ module mvdan.cc/garble
 
 go 1.14
 
-replace github.com/Binject/debug => /home/capnspacehook/go/src/github.com/Binject/debug
-
 require (
-	github.com/Binject/debug v0.0.0-20200725165605-6aefc612bb56
+	github.com/Binject/debug v0.0.0-20200827122705-d59c10f46e4f
 	github.com/google/go-cmp v0.5.1
 	github.com/rogpeppe/go-internal v1.6.0
 	golang.org/x/tools v0.0.0-20200622203043-20e05c1c8ffa

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/Binject/debug v0.0.0-20200827122705-d59c10f46e4f h1:bvClYXh1T4BVw3SZBfYTCPkmmF1qh/mZKRToTkDjaXc=
+github.com/Binject/debug v0.0.0-20200827122705-d59c10f46e4f/go.mod h1:QzgxDLY/qdKlvnbnb65eqTedhvQPbaSP2NqIbcuKvsQ=
 github.com/google/go-cmp v0.5.1 h1:JFrFEBb2xKufg6XkJsJr+WbKb4FQlURi5RUcBveYu9k=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=

--- a/import_obfuscation.go
+++ b/import_obfuscation.go
@@ -1,0 +1,190 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"sort"
+	"strings"
+
+	"github.com/Binject/debug/goobj2"
+)
+
+const (
+	goFilePrefix = "gofile.."
+)
+
+type pkgInfo struct {
+	pkg  *goobj2.Package
+	path string
+}
+
+func obfuscateImports(objPath, importCfgPath string) error {
+	importCfg, err := goobj2.ParseImportCfg(importCfgPath)
+	if err != nil {
+		return err
+	}
+	mainPkg, err := goobj2.Parse(objPath, "main", importCfg)
+	if err != nil {
+		return err
+	}
+	pkgs := []pkgInfo{{mainPkg, objPath}}
+
+	for pkgPath, info := range importCfg {
+		if isPrivate(pkgPath) {
+			pkg, err := goobj2.Parse(info.Path, pkgPath, importCfg)
+			if err != nil {
+				return err
+			}
+			pkgs = append(pkgs, pkgInfo{pkg, info.Path})
+		}
+	}
+
+	var sb strings.Builder
+	for _, p := range pkgs {
+		fmt.Printf("++ Obfuscating object file for %s ++\n", p.pkg.ImportPath)
+
+		var privateImports []string
+		if p.pkg.ImportPath != "main" && isPrivate(p.pkg.ImportPath) {
+			privateImports = append(privateImports, p.pkg.ImportPath)
+		}
+		for i := range p.pkg.Imports {
+			if isPrivate(p.pkg.Imports[i].Pkg) {
+				p.pkg.Imports[i].Pkg = hashWith("fakebuildID", p.pkg.Imports[i].Pkg)
+			}
+		}
+		for i := range p.pkg.Packages {
+			if isPrivate(p.pkg.Packages[i]) {
+				privateImports = append(privateImports, p.pkg.Packages[i])
+				p.pkg.Packages[i] = hashWith("fakebuildID", p.pkg.Packages[i])
+			}
+		}
+		sort.Slice(privateImports, func(i, j int) bool {
+			if strings.Contains(privateImports[i], privateImports[j]) {
+				return true
+			}
+			return false
+		})
+
+		fmt.Printf("== Private imports: %v ==\n", privateImports)
+		if len(privateImports) == 0 {
+			continue
+		}
+
+		lists := [][]*goobj2.Sym{p.pkg.SymDefs, p.pkg.NonPkgSymDefs, p.pkg.NonPkgSymRefs}
+		for _, list := range lists {
+			for _, s := range list {
+				s.Name = garbleSymbolName(s.Name, privateImports, &sb)
+				/*s.Data = garbleSymData(s.Data, privateImports)
+				if s.Size != 0 {
+					s.Size = uint32(len(s.Data))
+				}*/
+
+				for i := range s.Reloc {
+					s.Reloc[i].Name = garbleSymbolName(s.Reloc[i].Name, privateImports, &sb)
+				}
+				if s.Type != nil {
+					s.Type.Name = garbleSymbolName(s.Type.Name, privateImports, &sb)
+				}
+				if s.Func != nil {
+					for _, inl := range s.Func.InlTree {
+						inl.Func.Name = garbleSymbolName(inl.Func.Name, privateImports, &sb)
+					}
+				}
+			}
+		}
+		for i := range p.pkg.SymRefs {
+			p.pkg.SymRefs[i].Name = garbleSymbolName(p.pkg.SymRefs[i].Name, privateImports, &sb)
+		}
+
+		if err = goobj2.WriteObjFile2(p.pkg, p.path); err != nil {
+			return err
+		}
+	}
+
+	if err = goobj2.WriteObjFile2(pkgs[0].pkg, "/home/capnspacehook/Documents/obf_binclude.o"); err != nil {
+		return err
+	}
+
+	var cfgBuf bytes.Buffer
+	for pkgPath, info := range importCfg {
+		if isPrivate(pkgPath) {
+			pkgPath = hashWith("fakebuildID", pkgPath)
+		}
+		if info.IsSharedLib {
+			cfgBuf.WriteString("packageshlib")
+		} else {
+			cfgBuf.WriteString("packagefile")
+		}
+
+		cfgBuf.WriteRune(' ')
+		cfgBuf.WriteString(pkgPath)
+		cfgBuf.WriteRune('=')
+		cfgBuf.WriteString(info.Path)
+		cfgBuf.WriteRune('\n')
+	}
+
+	fmt.Print("\n\n")
+
+	if err = ioutil.WriteFile(importCfgPath, cfgBuf.Bytes(), 0644); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func garbleSymbolName(symName string, privateImports []string, sb *strings.Builder) (s string) {
+	var off int
+	for {
+		o, l := privateImportIndex(symName[off:], privateImports)
+		if o == -1 {
+			if sb.Len() != 0 {
+				sb.WriteString(symName[off:])
+			}
+			break
+		}
+
+		sb.WriteString(symName[off : off+o])
+		sb.WriteString(hashWith("fakebuildID", symName[off+o:off+o+l]))
+		off += o + l
+	}
+
+	if sb.Len() == 0 {
+		return symName
+	}
+
+	s = sb.String()
+	sb.Reset()
+
+	fmt.Printf("Garbled symbol: %s as %s\n", symName, s)
+
+	return s
+}
+
+func privateImportIndex(symName string, privateImports []string) (int, int) {
+	for _, privateImport := range privateImports {
+		off := strings.Index(symName, privateImport)
+		if off == -1 {
+			continue
+		}
+		return off, len(privateImport)
+	}
+
+	return -1, 0
+}
+
+func garbleSymData(data []byte, privateImports []string) []byte {
+	off := -1
+	for _, privateImport := range privateImports {
+		off = bytes.Index(data, []byte(privateImport))
+		if off == -1 {
+			continue
+		}
+
+		l := len(privateImport)
+		garbled := hashWith("fakebuildID", string(data[off:off+l]))
+		data = append(data[:off], append([]byte(garbled), data[off+l:]...)...)
+	}
+
+	return data
+}

--- a/import_obfuscation.go
+++ b/import_obfuscation.go
@@ -186,15 +186,24 @@ func garbleSymbolName(symName string, privateImports []string, sb *strings.Build
 }
 
 func privateImportIndex(symName string, privateImports []string) (int, int) {
+	firstOff, l := -1, 0
 	for _, privateImport := range privateImports {
 		off := strings.Index(symName, privateImport)
 		if off == -1 {
 			continue
 		}
-		return off, len(privateImport)
+
+		if off < firstOff || firstOff == -1 {
+			firstOff = off
+			l = len(privateImport)
+		}
 	}
 
-	return -1, 0
+	if firstOff == -1 {
+		return -1, 0
+	}
+
+	return firstOff, l
 }
 
 func garbleSymData(data []byte, privateImports []string, dataTyp dataType, buf *bytes.Buffer) (b []byte) {

--- a/import_obfuscation.go
+++ b/import_obfuscation.go
@@ -69,6 +69,9 @@ func obfuscateImports(objPath, importCfgPath string) error {
 		for i := range p.pkg.Packages {
 			if isPrivate(p.pkg.Packages[i]) {
 				privateImports = append(privateImports, p.pkg.Packages[i])
+				if strings.ContainsRune(p.pkg.Packages[i], '/') {
+					privateImports = append(privateImports, path.Base(p.pkg.Packages[i]))
+				}
 				p.pkg.Packages[i] = hashWith("fakebuildID", p.pkg.Packages[i])
 			}
 		}
@@ -112,6 +115,9 @@ func obfuscateImports(objPath, importCfgPath string) error {
 					s.Type.Name = garbleSymbolName(s.Type.Name, privateImports, &sb)
 				}
 				if s.Func != nil {
+					for i := range s.Func.FuncData {
+						s.Func.FuncData[i].Sym.Name = garbleSymbolName(s.Func.FuncData[i].Sym.Name, privateImports, &sb)
+					}
 					for _, inl := range s.Func.InlTree {
 						inl.Func.Name = garbleSymbolName(inl.Func.Name, privateImports, &sb)
 					}

--- a/import_obfuscation.go
+++ b/import_obfuscation.go
@@ -236,7 +236,7 @@ func hashImport(pkg string) string {
 	return hashWith(buildInfo.imports[pkg].buildID, pkg)
 }
 
-func garbleSymbolName(symName string, privateImports []string, sb *strings.Builder) (s string) {
+func garbleSymbolName(symName string, privateImports []string, sb *strings.Builder) string {
 	prefix, name, skipSym := splitSymbolPrefix(symName)
 	if skipSym {
 		return symName
@@ -262,9 +262,7 @@ func garbleSymbolName(symName string, privateImports []string, sb *strings.Build
 	}
 	defer sb.Reset()
 
-	s = prefix + sb.String()
-
-	return s
+	return prefix + sb.String()
 }
 
 var skipPrefixes = [...]string{
@@ -282,6 +280,11 @@ var symPrefixes = [...]string{
 	"go.interface.",
 	"go.map.",
 	"gofile..",
+	"type..eq.",
+	"type..eqfunc.",
+	"type..hash.",
+	"type..importpath.",
+	"type..namedata.",
 	"type.",
 }
 
@@ -356,7 +359,7 @@ func isSymbol(c byte) bool {
 
 }
 
-func garbleSymData(data []byte, privateImports []string, dataTyp dataType, buf *bytes.Buffer) (b []byte) {
+func garbleSymData(data []byte, privateImports []string, dataTyp dataType, buf *bytes.Buffer) []byte {
 	var symData []byte
 	switch dataTyp {
 	case importPath:

--- a/import_obfuscation.go
+++ b/import_obfuscation.go
@@ -357,10 +357,15 @@ func isSymbol(c byte) bool {
 }
 
 func garbleSymData(data []byte, privateImports []string, dataTyp dataType, buf *bytes.Buffer) (b []byte) {
-	symData := data
-	if dataTyp == namedata {
+	var symData []byte
+	switch dataTyp {
+	case importPath:
+		symData = data[3:]
+	case namedata:
 		oldNameLen := int(uint16(data[1])<<8 | uint16(data[2]))
 		symData = data[3 : 3+oldNameLen]
+	default:
+		symData = data
 	}
 
 	var off int

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ import (
 	"strings"
 
 	"golang.org/x/tools/go/ast/astutil"
+
 	"mvdan.cc/garble/internal/literals"
 )
 
@@ -292,7 +293,7 @@ func mainErr(args []string) error {
 			modpath, err := exec.Command("go", "list", "-m").Output()
 			if err == nil {
 				path := string(bytes.TrimSpace(modpath))
-				envGoPrivate = path+","+path+"_test"
+				envGoPrivate = path + "," + path + "_test"
 			}
 		}
 		// Explicitly set GOPRIVATE, since future garble processes won't
@@ -920,6 +921,11 @@ func transformLink(args []string) ([]string, error) {
 	if len(paths) == 0 {
 		// Nothing to transform; probably just ["-V=full"].
 		return args, nil
+	}
+
+	importCfgPath := flagValue(flags, "-importcfg")
+	if err := obfuscateImports(paths[0], importCfgPath); err != nil {
+		return nil, err
 	}
 
 	// Make sure -X works with garbled identifiers. To cover both garbled


### PR DESCRIPTION
Finally, finally this is done. This allows import paths to be obfuscated by modifying object/archive files and garbling import paths contained within. The bulk of the code that makes parsing and writing Go object/archive files possible lives at https://github.com/Binject/debug/tree/master/goobj2, which I wrote as well. 

Fixes #13. 