### PR TITLE
Garble imports and package paths in GOPRIVATE

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The tool wraps calls to the Go compiler and linker to transform the Go build, in
 order to:
 
 * Replace as many useful identifiers as possible with short base64 hashes
+* Replace package paths with short base64 hashes
 * Remove all [build](https://golang.org/pkg/runtime/#Version) and [module](https://golang.org/pkg/runtime/debug/#ReadBuildInfo) information
 * Strip filenames and shuffle position information
 * Obfuscate literals, if the `-literals` flag is given
@@ -43,9 +44,6 @@ packages to garble, set `GOPRIVATE`, documented at `go help module-private`.
 
 Most of these can improve with time and effort. The purpose of this section is
 to document the current shortcomings of this tool.
-
-* Package import path names are never garbled, since we require the original
-  paths for the build system to work. See #13 to investigate alternatives.
 
 * The `-a` flag for `go build` is required, since `-toolexec` doesn't work well
   with the build cache; see [golang/go#27628](https://github.com/golang/go/issues/27628).

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module mvdan.cc/garble
 go 1.15
 
 require (
+	github.com/Binject/debug v0.0.0-20200902173556-6349fcc2a6d1
 	github.com/google/go-cmp v0.5.2
 	github.com/rogpeppe/go-internal v1.6.2-0.20200830194709-1115b6af0369
 	golang.org/x/mod v0.3.1-0.20200828183125-ce943fd02449

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,10 @@
+github.com/Binject/debug v0.0.0-20200902173556-6349fcc2a6d1 h1:LZUTTfBjLy9K2gcUT5W/5jk5O8Gg7NTo8J5QY0ErTrM=
+github.com/Binject/debug v0.0.0-20200902173556-6349fcc2a6d1/go.mod h1:QzgxDLY/qdKlvnbnb65eqTedhvQPbaSP2NqIbcuKvsQ=
 github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
-github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/rogpeppe/go-internal v1.6.2-0.20200830194709-1115b6af0369 h1:wdCVGtPadWC/ZuuLC7Hv58VQ5UF7V98ewE71n5mJfrM=
 github.com/rogpeppe/go-internal v1.6.2-0.20200830194709-1115b6af0369/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
@@ -30,7 +31,6 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0 h1:0vLT13EuvQ0hNvakwLuFZ/jYrLp5F3kcWHXdRggjCE8=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=

--- a/import_obfuscation.go
+++ b/import_obfuscation.go
@@ -1,0 +1,535 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/Binject/debug/goobj2"
+)
+
+// pkgInfo stores a parsed go archive/object file,
+// and the original path to which it was read from.
+type pkgInfo struct {
+	pkg  *goobj2.Package
+	path string
+}
+
+// dataType signifies whether the Data portion of a
+// goobj2.Sym is reflection data for an import path,
+// reflection data for a method of struct field, or
+// something else.
+type dataType uint8
+
+const (
+	other dataType = iota
+	importPath
+	namedata
+)
+
+func obfuscateImports(objPath, importCfgPath string) (map[string]string, error) {
+	importCfg, err := goobj2.ParseImportCfg(importCfgPath)
+	if err != nil {
+		return nil, err
+	}
+	mainPkg, err := goobj2.Parse(objPath, "main", importCfg)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing main objfile: %v", err)
+	}
+	privatePkgs := []pkgInfo{{mainPkg, objPath}}
+
+	// build list of imported packages that are private
+	for pkgPath, info := range importCfg {
+		if isPrivate(pkgPath) {
+			pkg, err := goobj2.Parse(info.Path, pkgPath, importCfg)
+			if err != nil {
+				return nil, fmt.Errorf("error parsing objfile %s at %s: %v", pkgPath, info.Path, err)
+			}
+
+			privatePkgs = append(privatePkgs, pkgInfo{pkg, info.Path})
+		}
+	}
+
+	var sb strings.Builder
+	var buf bytes.Buffer
+	garbledImports := make(map[string]string)
+	for _, p := range privatePkgs {
+		// log.Printf("++ Obfuscating object file for %s ++", p.pkg.ImportPath)
+		for _, am := range p.pkg.ArchiveMembers {
+			// log.Printf("\t## Obfuscating archive member %s ##", am.ArchiveHeader.Name)
+			// skip objects that are not used by the linker, or that do not contain
+			// any Go symbol info
+			if am.IsCompilerObj() || am.IsDataObj() {
+				continue
+			}
+
+			// remove dwarf file list, it isn't needed as we pass "-w, -s" to the linker
+			am.DWARFFileList = nil
+
+			// add all private import paths to a list to garble
+			var privateImports []string
+			privateImports = append(privateImports, p.pkg.ImportPath)
+			if strings.ContainsRune(p.pkg.ImportPath, '/') {
+				privateImports = append(privateImports, importPathCombos(p.pkg.ImportPath)...)
+			}
+
+			initImport := func(imp string) string {
+				if !isPrivate(imp) {
+					return imp
+				}
+
+				privateImports = append(privateImports, imp)
+				if strings.ContainsRune(imp, '/') {
+					privateImports = append(privateImports, importPathCombos(imp)...)
+				}
+				return hashImport(imp, garbledImports)
+			}
+
+			for i := range am.Imports {
+				am.Imports[i].Pkg = initImport(am.Imports[i].Pkg)
+			}
+			for i := range am.Packages {
+				am.Packages[i] = initImport(am.Packages[i])
+			}
+
+			// move imports that contain another import as a substring to the front,
+			// so that the shorter import will not match first and leak part of an
+			// import path
+			sort.Slice(privateImports, func(i, j int) bool {
+				iSlashes := strings.Count(privateImports[i], "/")
+				jSlashes := strings.Count(privateImports[j], "/")
+				// sort by number of slashes first, then alphabetically
+				if iSlashes == jSlashes {
+					return privateImports[i] > privateImports[j]
+				}
+				return iSlashes > jSlashes
+			})
+			privateImports = dedupImportPaths(privateImports)
+
+			// no private import paths, nothing to garble
+			// log.Printf("\t== Private imports: %v ==\n", privateImports)
+			if len(privateImports) == 0 {
+				continue
+			}
+
+			// garble all private import paths in all symbol names
+			lists := [][]*goobj2.Sym{am.SymDefs, am.NonPkgSymDefs, am.NonPkgSymRefs}
+			for _, list := range lists {
+				for _, s := range list {
+					// skip debug symbols, and remove the debug symbol's data to save space
+					if s.Kind >= goobj2.SDWARFINFO && s.Kind <= goobj2.SDWARFLINES {
+						s.Data = nil
+						continue
+					}
+
+					// skip local asm symbols. For some reason garbling these breaks things
+					// add the symbol name to a blacklist, so we don't garble related symbols
+					if s.Kind == goobj2.SABIALIAS {
+						if parts := strings.SplitN(s.Name, ".", 2); parts[0] == "main" {
+							skipPrefixes = append(skipPrefixes, s.Name)
+							skipPrefixes = append(skipPrefixes, `"".`+parts[1])
+							continue
+						}
+					}
+
+					// garble read only static data, but not strings. If import paths are in strings,
+					// that means garbling strings might effect the behavior of the compiled binary
+					if s.Kind == goobj2.SRODATA && s.Data != nil && !strings.HasPrefix(s.Name, "go.string.") {
+						var dataTyp dataType
+						if strings.HasPrefix(s.Name, "type..importpath.") {
+							dataTyp = importPath
+						} else if strings.HasPrefix(s.Name, "type..namedata.") {
+							dataTyp = namedata
+						}
+						s.Data = garbleSymData(s.Data, privateImports, garbledImports, dataTyp, &buf)
+
+						if s.Size != 0 {
+							s.Size = uint32(len(s.Data))
+						}
+					}
+					s.Name = garbleSymbolName(s.Name, privateImports, garbledImports, &sb)
+
+					for i := range s.Reloc {
+						s.Reloc[i].Name = garbleSymbolName(s.Reloc[i].Name, privateImports, garbledImports, &sb)
+					}
+					if s.Type != nil {
+						s.Type.Name = garbleSymbolName(s.Type.Name, privateImports, garbledImports, &sb)
+					}
+					if s.Func != nil {
+						for i := range s.Func.FuncData {
+							s.Func.FuncData[i].Sym.Name = garbleSymbolName(s.Func.FuncData[i].Sym.Name, privateImports, garbledImports, &sb)
+						}
+						for _, inl := range s.Func.InlTree {
+							inl.Func.Name = garbleSymbolName(inl.Func.Name, privateImports, garbledImports, &sb)
+						}
+
+						// remove unneeded debug aux symbols
+						s.Func.DwarfInfo = nil
+						s.Func.DwarfLoc = nil
+						s.Func.DwarfRanges = nil
+						s.Func.DwarfDebugLines = nil
+					}
+				}
+			}
+			for i := range am.SymRefs {
+				am.SymRefs[i].Name = garbleSymbolName(am.SymRefs[i].Name, privateImports, garbledImports, &sb)
+			}
+		}
+
+		if err := p.pkg.Write(p.path); err != nil {
+			return nil, fmt.Errorf("error writing objfile %s at %s: %v", p.pkg.ImportPath, p.path, err)
+		}
+	}
+
+	// garble importcfg so the linker knows where to find garbled imports
+	newCfg, err := os.Create(importCfgPath)
+	if err != nil {
+		return nil, fmt.Errorf("error creating importcfg: %v", err)
+	}
+	defer newCfg.Close()
+	newCfgWr := bufio.NewWriter(newCfg)
+
+	for pkgPath, info := range importCfg {
+		if isPrivate(pkgPath) {
+			pkgPath = hashImport(pkgPath, garbledImports)
+		}
+		if info.IsSharedLib {
+			newCfgWr.WriteString("packageshlib")
+		} else {
+			newCfgWr.WriteString("packagefile")
+		}
+
+		newCfgWr.WriteRune(' ')
+		newCfgWr.WriteString(pkgPath)
+		newCfgWr.WriteRune('=')
+		newCfgWr.WriteString(info.Path)
+		newCfgWr.WriteRune('\n')
+	}
+
+	if err := newCfgWr.Flush(); err != nil {
+		return nil, fmt.Errorf("error writing importcfg: %v", err)
+	}
+
+	return garbledImports, nil
+}
+
+// importPathCombos returns a list of import paths that
+// could all potentially be in symbol names of the
+// package that imported 'path'.
+// TODO: last element returned should get same buildID
+// as full path?
+// ie github.com/foo/bar.buildID == bar.buildID
+func importPathCombos(path string) []string {
+	paths := strings.Split(path, "/")
+	combos := make([]string, 0, len(paths))
+
+	var restPrivate bool
+	if isPrivate(paths[0]) {
+		combos = append(combos, paths[0])
+		restPrivate = true
+	}
+
+	// find first private match
+	privateIdx := 1
+	if !restPrivate {
+		newPath := paths[0]
+		for i := 1; i < len(paths); i++ {
+			newPath += "/" + paths[i]
+			if isPrivate(newPath) {
+				combos = append(combos, paths[i])
+				combos = append(combos, newPath)
+
+				privateIdx = i + 1
+				restPrivate = true
+				break
+			}
+		}
+
+		if !restPrivate {
+			return nil
+		}
+	}
+
+	lastComboIdx := 2
+	for i := privateIdx; i < len(paths)-1; i++ {
+		combos = append(combos, paths[i])
+		combos = append(combos, combos[lastComboIdx-1]+"/"+paths[i])
+		lastComboIdx += 2
+	}
+	combos = append(combos, paths[len(paths)-1])
+
+	return combos
+}
+
+func dedupImportPaths(paths []string) []string {
+	seen := make(map[string]struct{}, len(paths))
+	j := 0
+	for _, v := range paths {
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		seen[v] = struct{}{}
+		paths[j] = v
+		j++
+	}
+	return paths[:j]
+}
+
+// TODO: possible that package collisions can occur; for instance, if
+// 'github.com/thingy/foo' and 'bar/baz/foo/zip' were both private imports
+// of the same object, 'foo' would be added to as a private import
+// twice, due to the logic of importPathCombos(). There needs to be some
+// way to differentiate between 'foo' of 'github.com/thingy/foo' and
+// 'bar/baz/foo/zip' so the same buildID is not used, which would create
+// an identical hash.
+func hashImport(pkg string, garbledImports map[string]string) string {
+	if garbledPkg, ok := garbledImports[pkg]; ok {
+		return garbledPkg
+	}
+
+	garbledPkg := hashWith(buildInfo.imports[pkg].buildID, pkg)
+	garbledImports[pkg] = garbledPkg
+
+	return garbledPkg
+}
+
+// garbleSymbolName finds all private imports in a symbol name, garbles them,
+// and returns the modified symbol name.
+func garbleSymbolName(symName string, privateImports []string, garbledImports map[string]string, sb *strings.Builder) string {
+	prefix, name, skipSym := splitSymbolPrefix(symName)
+	if skipSym {
+		// log.Printf("\t\t? Skipped symbol: %s", symName)
+		return symName
+	}
+
+	var off int
+	for {
+		o, l := privateImportIndex(name[off:], privateImports)
+		if o == -1 {
+			if sb.Len() != 0 {
+				sb.WriteString(name[off:])
+			}
+			break
+		}
+
+		sb.WriteString(name[off : off+o])
+		sb.WriteString(hashImport(name[off+o:off+o+l], garbledImports))
+		off += o + l
+	}
+
+	if sb.Len() == 0 {
+		// log.Printf("\t\t? Skipped symbol: %s", symName)
+		return symName
+	}
+	defer sb.Reset()
+
+	return prefix + sb.String()
+}
+
+// if symbols have one of these prefixes, skip
+// garbling
+// TODO: skip compiler generated/builtin symbols
+var skipPrefixes = []string{
+	// these symbols never contain import paths
+	"gclocals.",
+	"gclocals·",
+	// string names be what they be
+	"go.string.",
+
+	// skip entrypoint symbols
+	"main.init.",
+	"main..stmp",
+}
+
+// symbols that are related to the entrypoint
+// that cannot be garbled
+var entrypointSyms = [...]string{
+	"main.main",
+	"main..inittask",
+}
+
+// if any of these strings are found in a
+// symbol name, it should not be garbled
+var skipSubstrs = [...]string{
+	// skip test symbols
+	"_test.",
+}
+
+// prefixes of symbols that we will garble,
+// but we split the symbol name by one of
+// these prefixes so that we do not
+// accidentally garble an essential prefix
+var symPrefixes = [...]string{
+	"go.builtin.",
+	"go.itab.",
+	"go.itablink.",
+	"go.interface.",
+	"go.map.",
+	"gofile..",
+	"type..eq.",
+	"type..eqfunc.",
+	"type..hash.",
+	"type..importpath.",
+	"type..namedata.",
+	"type.",
+}
+
+// splitSymbolPrefix returns the symbol name prefix Go uses
+// to help designate the type of the symbol, and the rest of
+// the symbol name. Additionally, a bool is returned that
+// signifies whether garbling the symbol name should be skipped.
+func splitSymbolPrefix(symName string) (string, string, bool) {
+	if symName == "" {
+		return "", "", true
+	}
+
+	for _, prefix := range skipPrefixes {
+		if strings.HasPrefix(symName, prefix) {
+			return "", "", true
+		}
+	}
+
+	for _, entrySym := range entrypointSyms {
+		if symName == entrySym {
+			return "", "", true
+		}
+	}
+
+	for _, substr := range skipSubstrs {
+		if strings.Contains(symName, substr) {
+			return "", "", true
+		}
+	}
+
+	for _, prefix := range symPrefixes {
+		if strings.HasPrefix(symName, prefix) {
+			return symName[:len(prefix)], symName[len(prefix):], false
+		}
+	}
+
+	return "", symName, false
+}
+
+// privateImportIndex returns the offset and length of a private import
+// in symName. If no private imports from privateImports are present in
+// symName, -1, 0 is returned.
+func privateImportIndex(symName string, privateImports []string) (int, int) {
+	firstOff, l := -1, 0
+	for _, privateImport := range privateImports {
+		// search for the package name plus a period if the
+		// package name doesn't have slashes, to minimize the
+		// likelihood that the package isn't matched as a
+		// substring of another ident name.
+		// ex: privateImport = main, symName = "domainname"
+		var noSlashes bool
+		if !strings.ContainsRune(privateImport, '/') {
+			privateImport += "."
+			noSlashes = true
+		}
+
+		off := strings.Index(symName, privateImport)
+		if off == -1 {
+			continue
+			// check that we didn't match inside an import path. If the
+			// byte before the start of the match is not a small set of
+			// symbols that can make up a symbol name, we must have matched
+			// inside of an ident name as a substring. Or, if the byte
+			// before the start of the match is a forward slash, we are
+			// definitely inside of an input path.
+		} else if off != 0 && (!isSymbol(symName[off-1]) || symName[off-1] == '/') {
+			continue
+		}
+
+		if off < firstOff || firstOff == -1 {
+			firstOff = off
+			l = len(privateImport)
+			if noSlashes {
+				l--
+			}
+		}
+	}
+
+	if firstOff == -1 {
+		return -1, 0
+	}
+
+	return firstOff, l
+}
+
+func isSymbol(c byte) bool {
+	switch c {
+	case ' ', '(', ')', '*', ',', '[', ']', '_', '{', '}':
+		return true
+	default:
+		return false
+	}
+}
+
+// garbleSymData finds all private imports a symbol's data, garbles them, and
+// returns the modified symbol data.
+func garbleSymData(data []byte, privateImports []string, garbledImports map[string]string, dataTyp dataType, buf *bytes.Buffer) []byte {
+	var symData []byte
+	switch dataTyp {
+	case importPath:
+		symData = data[3:]
+	case namedata:
+		oldNameLen := int(uint16(data[1])<<8 | uint16(data[2]))
+		symData = data[3 : 3+oldNameLen]
+	default:
+		symData = data
+	}
+
+	var off int
+	for {
+		o, l := privateImportIndex(string(symData[off:]), privateImports)
+		if o == -1 {
+			if buf.Len() != 0 {
+				buf.Write(symData[off:])
+			}
+			break
+		}
+
+		if dataTyp == importPath {
+			return createImportPathData(hashImport(string(symData[o:o+l]), garbledImports))
+		}
+
+		buf.Write(symData[off : off+o])
+		buf.WriteString(hashImport(string(symData[off+o:off+o+l]), garbledImports))
+		off += o + l
+
+	}
+
+	if buf.Len() == 0 {
+		return data
+	}
+	defer buf.Reset()
+
+	if dataTyp == namedata {
+		return patchReflectData(buf.Bytes(), data)
+	}
+
+	return buf.Bytes()
+}
+
+func createImportPathData(importPath string) []byte {
+	l := 3 + len(importPath)
+	b := make([]byte, l)
+	b[0] = 0
+	b[1] = uint8(len(importPath) >> 8)
+	b[2] = uint8(len(importPath))
+	copy(b[3:], importPath)
+
+	return b
+}
+
+func patchReflectData(newName []byte, data []byte) []byte {
+	oldNameLen := int(uint16(data[1])<<8 | uint16(data[2]))
+
+	data[1] = uint8(len(newName) >> 8)
+	data[2] = uint8(len(newName))
+
+	return append(data[:3], append(newName, data[3+oldNameLen:]...)...)
+}

--- a/testdata/scripts/imports.txt
+++ b/testdata/scripts/imports.txt
@@ -1,11 +1,13 @@
 # Note that this is the only test with a module where we rely on the detection
 # of GOPRIVATE.
 
+env GOPRIVATE='test/*,rsc.io/*'
+
 garble build -tags buildtag
 exec ./main
 cmp stdout main.stdout
 
-! binsubstr main$exe 'ImportedVar' 'ImportedConst' 'ImportedFunc' 'ImportedType' 'main.go' 'imported.go'
+! binsubstr main$exe 'ImportedVar' 'ImportedConst' 'ImportedFunc' 'ImportedType' 'main.go' 'test/main' 'imported.' 'rsc.io'
 
 [short] stop # checking that the build is reproducible is slow
 
@@ -31,6 +33,7 @@ package main
 
 import (
 	"fmt"
+	"strings"
 	"reflect"
 	_ "unsafe"
 
@@ -48,11 +51,11 @@ func main() {
 	fmt.Println(imported.ImportedFunc('x'))
 	fmt.Println(imported.ImportedType(3))
 
-	fmt.Printf("%T\n", imported.ReflectTypeOf(2))
-	fmt.Printf("%T\n", imported.ReflectTypeOfIndirect(4))
+	fmt.Print(discardPackageName(fmt.Sprintf("%T\n", imported.ReflectTypeOf(2))))
+	fmt.Print(discardPackageName(fmt.Sprintf("%T\n", imported.ReflectTypeOfIndirect(4))))
 
 	v := imported.ReflectValueOfVar
-	fmt.Printf("%#v\n", v)
+	fmt.Print(discardPackageName(fmt.Sprintf("%#v\n", v)))
 	method := reflect.ValueOf(&v).MethodByName("ExportedMethodName")
 	if method.IsValid() {
 		fmt.Println(method.Call(nil))
@@ -62,6 +65,10 @@ func main() {
 
 	linkedPrintln(nil)
 	fmt.Println(quote.Go())
+}
+
+func discardPackageName(s string) string {
+	return strings.Split(s, ".")[1]
 }
 -- notag_fail.go --
 // +build !buildtag
@@ -119,9 +126,9 @@ imported var value
 imported const value
 x
 3
-imported.ReflectTypeOf
-imported.ReflectTypeOfIndirect
-imported.ReflectValueOf{ExportedField:"abc", unexportedField:""}
+ReflectTypeOf
+ReflectTypeOfIndirect
+ReflectValueOf{ExportedField:"abc", unexportedField:""}
 [method: abc]
 <nil>
 Don't communicate by sharing memory, share memory by communicating.

--- a/testdata/scripts/imports.txt
+++ b/testdata/scripts/imports.txt
@@ -1,13 +1,11 @@
 # Note that this is the only test with a module where we rely on the detection
 # of GOPRIVATE.
 
-env GOPRIVATE='test/*,rsc.io/*'
-
 garble build -tags buildtag
 exec ./main
 cmp stdout main.stdout
 
-! binsubstr main$exe 'ImportedVar' 'ImportedConst' 'ImportedFunc' 'ImportedType' 'main.go' 'test/main' 'imported.' 'rsc.io'
+! binsubstr main$exe 'ImportedVar' 'ImportedConst' 'ImportedFunc' 'ImportedType' 'main.go' 'test/main' 'imported.'
 
 [short] stop # checking that the build is reproducible is slow
 
@@ -51,11 +49,11 @@ func main() {
 	fmt.Println(imported.ImportedFunc('x'))
 	fmt.Println(imported.ImportedType(3))
 
-	fmt.Print(discardPackageName(fmt.Sprintf("%T\n", imported.ReflectTypeOf(2))))
-	fmt.Print(discardPackageName(fmt.Sprintf("%T\n", imported.ReflectTypeOfIndirect(4))))
+	printfWithoutPackage("%T\n", imported.ReflectTypeOf(2))
+	printfWithoutPackage("%T\n", imported.ReflectTypeOfIndirect(4))
 
 	v := imported.ReflectValueOfVar
-	fmt.Print(discardPackageName(fmt.Sprintf("%#v\n", v)))
+	printfWithoutPackage("%#v\n", v)
 	method := reflect.ValueOf(&v).MethodByName("ExportedMethodName")
 	if method.IsValid() {
 		fmt.Println(method.Call(nil))
@@ -67,8 +65,8 @@ func main() {
 	fmt.Println(quote.Go())
 }
 
-func discardPackageName(s string) string {
-	return strings.Split(s, ".")[1]
+func printfWithoutPackage(format string, v interface{}) {
+	fmt.Print(strings.Split(fmt.Sprintf(format, v), ".")[1])
 }
 -- notag_fail.go --
 // +build !buildtag

--- a/testdata/scripts/syntax.txt
+++ b/testdata/scripts/syntax.txt
@@ -1,10 +1,10 @@
-env GOPRIVATE=test/main
+env GOPRIVATE='test/main,rsc.io/*'
 
 garble -debugdir=debug build
 exec ./main$exe
 cmp stderr main.stderr
 
-! binsubstr main$exe 'localName' 'globalConst' 'globalVar' 'globalType' 'valuable information'
+! binsubstr main$exe 'localName' 'globalConst' 'globalVar' 'globalType' 'valuable information' 'rsc.io'
 
 binsubstr debug/main/scopes.go 'localName' 'globalConst'
 
@@ -26,6 +26,8 @@ package main
 import (
 	"encoding/json"
 	"go/ast"
+
+	"rsc.io/quote"
 )
 
 // This comment contains valuable information. Ensure it's not in the final binary.
@@ -70,6 +72,7 @@ func main() {
 	enc, _ := json.Marshal(EncodingT{Foo: 3})
 	println(string(enc))
 	scopesTest()
+	println(quote.Go())
 }
 
 -- scopes.go --
@@ -107,3 +110,4 @@ nil case
 {"Foo":3}
 1 1 1
 1 4 5 1 input
+Don't communicate by sharing memory, share memory by communicating.


### PR DESCRIPTION
Finally, finally this is done. This allows import paths to be obfuscated by modifying object/archive files and garbling import paths contained within. The bulk of the code that makes parsing and writing Go object/archive files possible lives at https://github.com/Binject/debug/tree/master/goobj2, which I wrote as well. 

I have tested by garbling and checking for import paths via `strings` and `grep` (in order of difficulty) https://github.com/lu4p/binclude, garble itself, and https://github.com/dominikh/go-tools/tree/master/cmd/staticcheck.

This only supports object/archive files produced from the Go 1.15 compiler. The object file format changed at 1.15, and 1.14 and earlier is not supported. 

Currently this breaks a few tests, I'm going to need help fixing them because it looks like many tests fail due to expected import paths no longer showing up in binaries.

Fixes #13. 